### PR TITLE
Upgrade to Pico SDK 2.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
     pull_request:
 
 env:
-    PICO_SDK_COMMIT_HASH: 6a7db34ff63345a7badec79ebea3aaef1712f374
+    PICO_SDK_COMMIT_HASH: efe2103f9b28458a1615ff096054479743ade236
 
 jobs:
     build_pico_asha:
@@ -33,6 +33,7 @@ jobs:
                 submodules: recursive
                 ref: "${{ env.PICO_SDK_COMMIT_HASH }}"
 
+            # Note: still required as of Pico SDK 2.0.0
             - name: Apply Bluetooth DLE patch
               if: steps.cache-pico-sdk.outputs.cache-hit != 'true'
               run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,13 @@
 cmake_minimum_required(VERSION 3.13)
 
+set(PICO_BOARD pico_w)
 include(pico_sdk_import.cmake)
 
 project(pico_asha C CXX)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-set(PICO_BOARD pico_w)
+
 pico_sdk_init()
 
 Include(FetchContent)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,11 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 pico_sdk_init()
 
+message("Pico SDK version is ${PICO_SDK_VERSION_STRING}")
+if(PICO_SDK_VERSION_STRING VERSION_LESS "2.0.0")
+  message( FATAL_ERROR "Pico SDK version must be 2.0.0 or greater" )
+endif()
+
 Include(FetchContent)
 
 FetchContent_Declare(

--- a/pico_sdk_import.cmake
+++ b/pico_sdk_import.cmake
@@ -18,9 +18,20 @@ if (DEFINED ENV{PICO_SDK_FETCH_FROM_GIT_PATH} AND (NOT PICO_SDK_FETCH_FROM_GIT_P
     message("Using PICO_SDK_FETCH_FROM_GIT_PATH from environment ('${PICO_SDK_FETCH_FROM_GIT_PATH}')")
 endif ()
 
+if (DEFINED ENV{PICO_SDK_FETCH_FROM_GIT_TAG} AND (NOT PICO_SDK_FETCH_FROM_GIT_TAG))
+    set(PICO_SDK_FETCH_FROM_GIT_TAG $ENV{PICO_SDK_FETCH_FROM_GIT_TAG})
+    message("Using PICO_SDK_FETCH_FROM_GIT_TAG from environment ('${PICO_SDK_FETCH_FROM_GIT_TAG}')")
+endif ()
+
+if (PICO_SDK_FETCH_FROM_GIT AND NOT PICO_SDK_FETCH_FROM_GIT_TAG)
+  set(PICO_SDK_FETCH_FROM_GIT_TAG "master")
+  message("Using master as default value for PICO_SDK_FETCH_FROM_GIT_TAG")
+endif()
+
 set(PICO_SDK_PATH "${PICO_SDK_PATH}" CACHE PATH "Path to the Raspberry Pi Pico SDK")
 set(PICO_SDK_FETCH_FROM_GIT "${PICO_SDK_FETCH_FROM_GIT}" CACHE BOOL "Set to ON to fetch copy of SDK from git if not otherwise locatable")
 set(PICO_SDK_FETCH_FROM_GIT_PATH "${PICO_SDK_FETCH_FROM_GIT_PATH}" CACHE FILEPATH "location to download SDK")
+set(PICO_SDK_FETCH_FROM_GIT_TAG "${PICO_SDK_FETCH_FROM_GIT_TAG}" CACHE FILEPATH "release tag for SDK")
 
 if (NOT PICO_SDK_PATH)
     if (PICO_SDK_FETCH_FROM_GIT)
@@ -34,14 +45,14 @@ if (NOT PICO_SDK_PATH)
             FetchContent_Declare(
                     pico_sdk
                     GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
-                    GIT_TAG master
+                    GIT_TAG ${PICO_SDK_FETCH_FROM_GIT_TAG}
                     GIT_SUBMODULES_RECURSE FALSE
             )
         else ()
             FetchContent_Declare(
                     pico_sdk
                     GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
-                    GIT_TAG master
+                    GIT_TAG ${PICO_SDK_FETCH_FROM_GIT_TAG}
             )
         endif ()
 


### PR DESCRIPTION
This PR upgrades to the newly released Pico SDK 2.0.0

To update your local pico sdk installation, cd into the pico sdk directory and run `git pull --recurse`.

Unfortunately, the new SDK _still_ does not include the updated BT firmware with the DLE fix, so you will need to re-apply the patch as described in the readme.

Version 2.0.0 and greater will be the supported SDK versions going forward. I will start using functionality from it that isn't available in older SDK versions.