### PR TITLE
USB serial improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ option(ENABLE_BLE_AD_DUMP "Enable dumping of advertisement packet data" OFF)
 option(ENABLE_HCI_DUMP "Enable HCI dump." OFF)
 option(ENABLE_UAC2_LOG "Enable USB logging" OFF)
 option(ENABLE_PAIR_DEL "Delete all HA pairings" OFF)
-option(ENABLE_USB_SERIAL "Enable USB serial support" OFF)
+option(ENABLE_USB_SERIAL "Enable USB serial support" ON)
 
 if(ENABLE_BLE_LOG_AUDIO)
   list(APPEND pico_asha_defines "ASHA_LOG_AUDIO")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,8 @@ endif()
 
 if(ENABLE_USB_SERIAL)
   list(APPEND pico_asha_defines "ASHA_USB_SERIAL")
+  list(APPEND pico_asha_defines "PICO_STDIO_USB_ENABLE_RESET_VIA_BAUD_RATE=1")
+
   pico_enable_stdio_usb(pico-asha 1)
   pico_enable_stdio_uart(pico-asha 0)
 else()

--- a/README.md
+++ b/README.md
@@ -52,16 +52,23 @@ Instructions for doing so are outside the scope of this readme.
 
 ### Serial
 
-By default, Pico-ASHA logs output via UART. To view debugging info over UART, you will need a method to interface with the UART pins. Such options include another pico using the [debugprobe](https://github.com/raspberrypi/debugprobe) project, a USB to UART adapter, The Raspberry Pi debug probe, a full Raspberry Pi or other SBC etc.
+#### USB
 
-Alternatively, Pico-ASHA can log output via USB serial using the standard Raspberry Pi Pico serial settings:
+By default, Pico-ASHA logs output via USB serial. The USB serial settings are as follows:
+
 - **Baud Rate:** 115200
 - **Data Bits:** 8
 - **Stop Bits:"** 1
 - **Parity:** None
 - **DTR** and **RTS** enabled
 
-Pass `-DENABLE_USB_SERIAL=ON` to cmake during configure to enable USB serial.
+You can also reset the Pico into `BOOTSEL` mode (to upload new firmware) by changing the baud rate to 1200 baud.
+
+#### UART
+
+Alternatively, Pico-ASHA can log output via UART. To view debugging info over UART, you will need a method to interface with the UART pins. Such options include another pico using the [debugprobe](https://github.com/raspberrypi/debugprobe) project, a USB to UART adapter, The Raspberry Pi debug probe, a full Raspberry Pi or other SBC etc.
+
+Pass `-DENABLE_USB_SERIAL=OFF` to cmake during configure to enable UART serial.
 
 ### Testing
 

--- a/src/asha_bt.cpp
+++ b/src/asha_bt.cpp
@@ -1,6 +1,10 @@
 #include "pico/cyw43_arch.h"
 #include "pico/time.h"
 
+#ifdef ASHA_USB_SERIAL
+    #include "pico/stdio_usb.h"
+#endif
+
 #include "asha_logging.h"
 #include "asha_uuid.hpp"
 #include "asha_bt.hpp"
@@ -153,7 +157,10 @@ extern "C" void bt_main()
 {
 #ifdef ASHA_USB_SERIAL
     // Allow time for USB serial to connect before proceeding
-    sleep_ms(5000);
+    while (!stdio_usb_connected()) {
+        sleep_ms(250);
+    }
+    sleep_ms(250);
 #endif
 
     LOG_INFO("BT ASHA starting.");

--- a/src/tusb_config.h
+++ b/src/tusb_config.h
@@ -30,7 +30,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-
+#include "pico/stdio_usb.h"
 #include "usb_descriptors.h"
 
 //--------------------------------------------------------------------+

--- a/src/tusb_config.h
+++ b/src/tusb_config.h
@@ -30,7 +30,10 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-#include "pico/stdio_usb.h"
+
+#ifdef ASHA_USB_SERIAL
+    #include "pico/stdio_usb.h"
+#endif
 #include "usb_descriptors.h"
 
 //--------------------------------------------------------------------+


### PR DESCRIPTION
This PR makes a couple of improvements to the USB serial support.

When using USB serial, Pico-ASHA won't proceed with BT startup until a terminal is connected. This allows for debugging without missing any critical messages. This may be changed in the future, because having to connect a terminal before proceeding will interfere with intended "plug and play" usage.

I have enabled the "reset to BOOTSEL mode" by changing the baud rate. If the baud rate is changed to 1200 baud, the Pico will reset to BOOTSEL mode without having to unplug USB and press the BOOTSEL button. A potential future desktop companion application may use this functionality to upgrade/switch firmware.

Pico-ASHA now defaults to USB serial to make it easier for testers without the capabilities of connecting via UART