### PR TITLE
Add basic connection status via onboard LED

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ add_executable(pico-asha
   src/asha_audio.cpp
   src/asha_bt.cpp
   src/asha_logging.cpp
+  src/asha_led.cpp
   src/hearing_aid.cpp
   src/usb_descriptors.cpp
   src/usb_audio.cpp

--- a/src/asha_bt.cpp
+++ b/src/asha_bt.cpp
@@ -500,6 +500,11 @@ static void hci_event_handler(uint8_t packet_type, uint16_t channel, uint8_t *pa
             LOG_INFO("%s: Disconnected with %hu available credits.", ha.side_str, ha.avail_credits);
             ha_mgr.remove_by_conn_handle(c);
         }
+        if (ha_mgr.hearing_aids.size() > 0) {
+            led_mgr.set_led_pattern(one_connected);
+        } else {
+            led_mgr.set_led_pattern(none_connected);
+        }
         scan_state = ScanState::Scan;
         curr_scan.reset();
         break;

--- a/src/asha_led.cpp
+++ b/src/asha_led.cpp
@@ -1,0 +1,50 @@
+#include <bitset>
+
+#include "asha_led.hpp"
+#include "pico/cyw43_arch.h"
+
+namespace asha
+{
+
+LEDManager::LEDManager()
+{
+    led_worker.user_data = this;
+}
+
+void LEDManager::set_led(LEDManager::State led_state)
+{
+    disable_curr_led_pattern();
+    cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, (led_state == State::On) ? true : false);
+}
+
+void LEDManager::set_led_pattern(LEDManager::Pattern const& pattern)
+{
+    if (pattern.len > 32 || !led_ctx) return;
+    disable_curr_led_pattern();
+    curr_pattern = pattern;
+    async_context_add_at_time_worker_in_ms(led_ctx, &led_worker, 0);
+}
+
+void LEDManager::handle_led_work(async_context_t* ctx, async_at_time_worker_t *worker)
+{
+    LEDManager *this_ = (LEDManager*)worker->user_data;
+    Pattern& p = this_->curr_pattern;
+    std::bitset<32> pattern_bitset(p.pattern);
+    cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, pattern_bitset[p.pos]);
+    ++p.pos;
+    if (p.pos >= p.len) {
+        p.pos = 0;
+        async_context_add_at_time_worker_in_ms(this_->led_ctx, &this_->led_worker, p.interval_ms + p.delay_ms);
+    } else {
+        async_context_add_at_time_worker_in_ms(this_->led_ctx, &this_->led_worker, p.interval_ms);
+    }
+}
+
+void LEDManager::disable_curr_led_pattern()
+{
+    if (led_ctx) {
+        async_context_remove_at_time_worker(led_ctx, &led_worker);
+    }
+}
+
+} // namespace asha

--- a/src/asha_led.hpp
+++ b/src/asha_led.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <cstdint>
+
+#include "pico/async_context.h"
+
+namespace asha
+{
+
+class LEDManager
+{
+public:
+    struct Pattern {
+        // Number of bits in the sequence. Can be up to 32
+        size_t len = 0;
+
+        // Time between each bit in the sequence
+        uint32_t interval_ms = 0;
+
+        // Delay after last bit before restarting sequence
+        uint32_t delay_ms = 0;
+
+        // Sequence bit pattern. If bit is set, LED will be ON, otherwise
+        // LED will be OFF
+        uint32_t pattern = 0;
+
+        // Current position in sequence
+        size_t pos = 0;
+    };
+
+    enum class State { On, Off };
+
+    LEDManager();
+
+    void set_ctx(async_context_t* ctx) {led_ctx = ctx;}
+    void set_led(State led_state);
+    void set_led_pattern(Pattern const& pattern);
+private:
+    void disable_curr_led_pattern();
+    static void handle_led_work(async_context_t* ctx, async_at_time_worker_t *worker);
+    async_context_t *led_ctx = nullptr;
+    async_at_time_worker_t led_worker = {.do_work = &LEDManager::handle_led_work};
+    Pattern curr_pattern = {};
+};
+
+} // namespace asha


### PR DESCRIPTION
This PR adds a basic connection status indication via the onboard LED.

Currently, it blinks when waiting for devices to connect. It blinks faster when one device is connected and it's waiting for the other.

The LED turns solid when all devices in a set are connected.

In the future, I might add more complex indicators.