### PR TITLE
Pair using GUI

### DIFF
--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -24,7 +24,10 @@ qt_add_executable(PicoASHAGui
     ../include/asha_comms.hpp
     ../include/bt_status_err.hpp
     ../lib/nanocobs/cobs.c
-    picoashamainwindow.h picoashamainwindow.cpp
+    picoashamainwindow.h 
+    picoashamainwindow.cpp
+    pairdialog.h 
+    pairdialog.cpp
 )
 
 target_include_directories(PicoASHAGui PUBLIC "${ASHA_COMM_INCLUDE_PATH}" "${ASHA_COMM_LIB_PATH}")

--- a/gui/pairdialog.cpp
+++ b/gui/pairdialog.cpp
@@ -1,0 +1,69 @@
+#include <QDialogButtonBox>
+#include <QPushButton>
+#include <QVBoxLayout>
+#include <QListWidgetItem>
+
+#include "pairdialog.h"
+
+PairDialog::PairDialog(QWidget *parent) : QDialog(parent)
+{
+    m_adListWidget = new QListWidget(this);
+    m_adListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
+    QDialogButtonBox* bb = new QDialogButtonBox(this);
+    bb->addButton("Pair", QDialogButtonBox::AcceptRole);
+    QObject::connect(bb, &QDialogButtonBox::accepted, this, [=,this]() {
+        auto selections = m_adListWidget->selectedItems();
+        if (!selections.empty()) {
+            auto selected = selections.at(0);
+            auto addrHex = selected->text().sliced(0, 17);
+            if (m_adMap.contains(addrHex)) {
+                auto a = m_adMap.value(addrHex);
+                emit addressSelected(a.addr, a.addr_type);
+            }
+        }
+        this->accept();
+    });
+
+    QVBoxLayout* layout = new QVBoxLayout;
+    layout->addWidget(m_adListWidget);
+    layout->addWidget(bb);
+    this->setLayout(layout);
+}
+
+void PairDialog::setAdPacket(const asha::comm::AdvertisingPacket &ad_pkt)
+{
+    QByteArray addr = QByteArray((const char*)ad_pkt.addr, sizeof(ad_pkt.addr));
+    QString addrStr = addr.toHex(':');
+    if (m_adMap.contains(addrStr)) {
+        bool updateList = false;
+        auto a = m_adMap.value(addrStr);
+        if (a.rssi != ad_pkt.rssi) {
+            updateList = true;
+            a.rssi = ad_pkt.rssi;
+        }
+        if (ad_pkt.is_ha && !a.is_ha) {
+            updateList = true;
+            a.is_ha = true;
+        }
+        if (a.name.isEmpty() && ad_pkt.name[0] != '\0') {
+            updateList = true;
+            a.name = ad_pkt.name;
+        }
+        if (updateList) {
+            auto lw = m_adListWidget->findItems(addrStr, Qt::MatchStartsWith);
+            if (!lw.empty()) {
+                auto w = lw.at(0);
+                w->setText(QString("%1 (%2) rssi: %3").arg(addrStr).arg(a.name).arg(a.rssi));
+            }
+        }
+    } else {
+        AdDetails a;
+        a.addr = addr;
+        a.addr_type = ad_pkt.addr_type;
+        a.rssi = ad_pkt.rssi;
+        a.is_ha = ad_pkt.is_ha;
+        a.name = ad_pkt.name;
+        m_adMap[addrStr] = a;
+        new QListWidgetItem(QString("%1 (%2) rssi: %3").arg(addrStr).arg(a.name).arg(a.rssi), m_adListWidget);
+    }
+}

--- a/gui/pairdialog.cpp
+++ b/gui/pairdialog.cpp
@@ -35,17 +35,18 @@ void PairDialog::setAdPacket(const asha::comm::AdvertisingPacket &ad_pkt)
     QByteArray addr = QByteArray((const char*)ad_pkt.addr, sizeof(ad_pkt.addr));
     QString addrStr = addr.toHex(':');
     if (m_adMap.contains(addrStr)) {
+        QString name = ad_pkt.name;
         bool updateList = false;
         auto a = m_adMap.value(addrStr);
-        if (a.rssi != ad_pkt.rssi) {
-            updateList = true;
-            a.rssi = ad_pkt.rssi;
-        }
+        // if (a.rssi != ad_pkt.rssi) {
+        //     updateList = true;
+        //     a.rssi = ad_pkt.rssi;
+        // }
         if (ad_pkt.is_ha && !a.is_ha) {
             updateList = true;
             a.is_ha = true;
         }
-        if (a.name.isEmpty() && ad_pkt.name[0] != '\0') {
+        if (a.name.isEmpty() && !name.isEmpty()) {
             updateList = true;
             a.name = ad_pkt.name;
         }
@@ -53,7 +54,7 @@ void PairDialog::setAdPacket(const asha::comm::AdvertisingPacket &ad_pkt)
             auto lw = m_adListWidget->findItems(addrStr, Qt::MatchStartsWith);
             if (!lw.empty()) {
                 auto w = lw.at(0);
-                w->setText(QString("%1 (%2) rssi: %3").arg(addrStr).arg(a.name).arg(a.rssi));
+                w->setText(QString("%1 (%2)").arg(addrStr).arg(a.name));
             }
         }
     } else {
@@ -63,7 +64,9 @@ void PairDialog::setAdPacket(const asha::comm::AdvertisingPacket &ad_pkt)
         a.rssi = ad_pkt.rssi;
         a.is_ha = ad_pkt.is_ha;
         a.name = ad_pkt.name;
-        m_adMap[addrStr] = a;
-        new QListWidgetItem(QString("%1 (%2) rssi: %3").arg(addrStr).arg(a.name).arg(a.rssi), m_adListWidget);
+        if (a.is_ha) {
+            m_adMap[addrStr] = a;
+            new QListWidgetItem(QString("%1 (%2)").arg(addrStr).arg(a.name), m_adListWidget);
+        }
     }
 }

--- a/gui/pairdialog.h
+++ b/gui/pairdialog.h
@@ -1,0 +1,36 @@
+#ifndef PAIRDIALOG_H
+#define PAIRDIALOG_H
+
+#include <QByteArray>
+#include <QDialog>
+#include <QListWidget>
+#include <QMap>
+#include <QString>
+
+#include <asha_comms.hpp>
+
+struct AdDetails {
+    QByteArray addr;
+    uint8_t addr_type;
+    uint8_t rssi;
+    bool is_ha;
+    QString name;
+};
+
+class PairDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit PairDialog(QWidget *parent = nullptr);
+
+    void setAdPacket(asha::comm::AdvertisingPacket const& ad_pkt);
+
+signals:
+    void addressSelected(QByteArray const& addr, uint8_t addr_type);
+private:
+    QMap<QString, AdDetails> m_adMap;
+    QListWidget* m_adListWidget;
+};
+
+#endif // PAIRDIALOG_H

--- a/gui/picoashacomm.cpp
+++ b/gui/picoashacomm.cpp
@@ -452,6 +452,12 @@ void PicoAshaComm::handleEventPacket(asha::comm::HeaderPacket const header, asha
         }
         if (rem) rem->setFwVersion(pkt.data.str);
         break;
+    case EventType::SWRead:
+        if (checkError(header, pkt, "SoftwareRead")) {
+            return;
+        }
+        if (rem) rem->setSwVersion(pkt.data.str);
+        break;
     case EventType::L2CAPCon:
         if (checkError(header, pkt, "L2CAPConnected")) {
             return;

--- a/gui/picoashacomm.h
+++ b/gui/picoashacomm.h
@@ -89,6 +89,7 @@ public slots:
     void onCmdConnAllowedBtnClicked(bool allowed);
     void onCmdStreamingEnabledBtnClicked(bool enabled);
     void onCmdRemoveBondBtnClicked();
+    void onPairWithAddress(QByteArray const& addr, uint8_t addr_type);
 };
 
 #endif // PICOASHACOMM_H

--- a/gui/picoashamainwindow.cpp
+++ b/gui/picoashamainwindow.cpp
@@ -16,6 +16,7 @@ static QString widgetNameFromConnID(uint16_t connID)
 PicoAshaMainWindow::PicoAshaMainWindow(QWidget *parent)
     : QMainWindow(parent)
 {
+    m_currPairDlg = nullptr;
     m_mainWidget = new QWidget;
     auto mainVBox = new QVBoxLayout;
 
@@ -269,6 +270,23 @@ void PicoAshaMainWindow::setHciActionBtnStop(bool enabled)
 {
     m_hciActionBtn->setText("HCI Stop");
     m_hciActionBtn->setEnabled(enabled);
+}
+
+void PicoAshaMainWindow::onAdPacketReceived(const asha::comm::AdvertisingPacket &ad_pkt)
+{
+    if (!m_currPairDlg) {
+        m_currPairDlg = new PairDialog(this);
+        QObject::connect(m_currPairDlg, &PairDialog::addressSelected, this, &PicoAshaMainWindow::pairWithAddress);
+        QObject::connect(m_currPairDlg, &PairDialog::accepted, this, &PicoAshaMainWindow::onPairDialogAcceptedRejected);
+        m_currPairDlg->open();
+    }
+    m_currPairDlg->setAdPacket(ad_pkt);
+}
+
+void PicoAshaMainWindow::onPairDialogAcceptedRejected()
+{
+    m_currPairDlg->deleteLater();
+    m_currPairDlg = nullptr;
 }
 
 void PicoAshaMainWindow::onSerialConnected(bool connected)

--- a/gui/picoashamainwindow.h
+++ b/gui/picoashamainwindow.h
@@ -9,6 +9,7 @@
 #include <QList>
 
 #include "remotedevice.h"
+#include "pairdialog.h"
 #include "asha_comms.hpp"
 
 class PicoAshaMainWindow : public QMainWindow
@@ -42,6 +43,11 @@ public:
     void setHciActionBtnStart(bool enabled);
     void setHciActionBtnStop(bool enabled);
 
+    void onAdPacketReceived(asha::comm::AdvertisingPacket const& ad_pkt);
+
+public slots:
+    void onPairDialogAcceptedRejected();
+
 signals:
     void hciLogPathChanged(QString const& path);
     void hciLogActionBtnClicked();
@@ -49,6 +55,7 @@ signals:
     void cmdConnAllowedBtnClicked(bool allowed);
     void cmdStreamingEnabledBtnClicked(bool enabled);
     void cmdRemoveBondBtnClicked();
+    void pairWithAddress(QByteArray const& addr, uint8_t addr_type);
 
 private:
     QWidget* m_mainWidget;
@@ -65,6 +72,8 @@ private:
     QPushButton* m_hciActionBtn;
     QPushButton* m_hciPathBtn;
     QLabel* m_hciPathLbl;
+
+    PairDialog* m_currPairDlg;
 
     bool m_serialConnected;
     bool m_connectionsAllowed;

--- a/gui/remotedevice.cpp
+++ b/gui/remotedevice.cpp
@@ -22,6 +22,7 @@ void RemoteDevice::setRemoteInfo(const asha::comm::RemoteInfo &remote)
     setMfgName(remote.mfg_name);
     setModelName(remote.model_name);
     setFwVersion(remote.fw_vers);
+    setSwVersion(remote.sw_vers);
     setSide(remote.side);
     setMode(remote.mode);
     setAudioStreaming(remote.audio_streaming);
@@ -49,6 +50,7 @@ void RemoteDevice::setCachedProps(CachedProps const& props)
     setModelName(props.modelName);
     setMfgName(props.mfgName);
     setFwVersion(props.fwVersion);
+    setSwVersion(props.swVersion);
     setG24KHz(props.g24kHZ);
     setMode(props.mode);
     setSide(props.side);
@@ -108,6 +110,12 @@ void RemoteDevice::setFwVersion(QString const& fwVersion)
 {
     m_fwVersionLabel.setText(fwVersion);
     m_cachedProps.fwVersion = fwVersion;
+}
+
+void RemoteDevice::setSwVersion(QString const& swVersion)
+{
+    m_swVersionLabel.setText(swVersion);
+    m_cachedProps.swVersion = swVersion;
 }
 
 void RemoteDevice::setSide(Side side)
@@ -170,6 +178,7 @@ void RemoteDevice::setDefaultValues()
     m_mfgNameLabel.setText("");
     m_modelNameLabel.setText("");
     m_fwVersionLabel.setText("");
+    m_swVersionLabel.setText("");
     m_modeLabel.setText("Unknown");
     m_g72224Label.setText("No");
     m_psmLabel.setText("0x00");
@@ -211,6 +220,7 @@ void RemoteDevice::setupUI()
     addRowToLayout("Make", &m_mfgNameLabel);
     addRowToLayout("Model", &m_modelNameLabel);
     addRowToLayout("FW Version", &m_fwVersionLabel);
+    addRowToLayout("SW Version", &m_swVersionLabel);
     addRowToLayout("Mode", &m_modeLabel);
     addRowToLayout("24 kHz Support", &m_g72224Label);
     addRowToLayout("PSM", &m_psmLabel);

--- a/gui/remotedevice.h
+++ b/gui/remotedevice.h
@@ -26,6 +26,7 @@ public:
         QString mfgName;
         QString modelName;
         QString fwVersion;
+        QString swVersion;
         Side side;
         Mode mode;
         bool g24kHZ;
@@ -55,6 +56,7 @@ public:
     void setMfgName(QString const& mfgName);
     void setModelName(QString const& modelName);
     void setFwVersion(QString const& fwVersion);
+    void setSwVersion(QString const& swVersion);
     void setSide(Side side);
     void setSide(asha::comm::CSide side);
     void setMode(Mode mode);
@@ -83,6 +85,7 @@ private:
     QLabel m_mfgNameLabel;
     QLabel m_modelNameLabel;
     QLabel m_fwVersionLabel;
+    QLabel m_swVersionLabel;
     QLabel m_modeLabel;
     QLabel m_g72224Label;
     QLabel m_psmLabel;

--- a/include/asha_comms.hpp
+++ b/include/asha_comms.hpp
@@ -24,6 +24,7 @@ namespace comm
         Event,
         HCI,
         Cmd,
+        Advert
     };
 
     enum class StatusType : uint8_t
@@ -95,6 +96,7 @@ namespace comm
         AllowConnect,
         AudioStreaming,
         IntroPacket,
+        PairBond,
     };
 
     enum class CmdStatus : uint8_t
@@ -213,10 +215,27 @@ namespace comm
             bool      enable_hci;
             bool      allow_connect;
             bool      audio_streaming_enabled;
+            struct {
+                uint8_t addr[6];
+                uint8_t addr_type;
+                uint8_t reserved[3];
+            } pair_bond;
         } data;
     };
 
-    static_assert(sizeof(CmdPacket) == 4);
+    static_assert(sizeof(CmdPacket) == 12);
+
+    struct AdvertisingPacket
+    {
+        uint8_t addr[6] = {};
+        uint8_t addr_type;
+        uint8_t rssi;
+        bool    is_ha;
+        uint8_t reserved[3];
+        char    name[28] = {};
+    };
+
+    static_assert(sizeof(AdvertisingPacket) == 40);
 
     void add_event_to_buffer(uint16_t const conn_id, EventPacket const& event);
 
@@ -224,6 +243,7 @@ namespace comm
 
     void send_intro_packet(int8_t num_connections, uint16_t flags = 0x00);
     void send_remote_info_packet(RemoteInfo const& remote_info);
+    void send_advertising_packet(AdvertisingPacket const& ad_packet);
 
     bool get_cmd_packet(HeaderPacket& header, CmdPacket& cmd_packet);
     void send_cmd_resp(uint16_t const conn_id, CmdPacket const& resp);

--- a/include/asha_comms.hpp
+++ b/include/asha_comms.hpp
@@ -70,6 +70,8 @@ namespace comm
         ModelRead,
         // Data is up to 32 byte null terminated string
         FWRead,
+        // Data is up to 32 byte null terminated string
+        SWRead,
         L2CAPCon,
         L2CAPDiscon,
         ASPNotEnable,
@@ -152,13 +154,14 @@ namespace comm
         char mfg_name[32];
         char model_name[32];
         char fw_vers[32];
+        char sw_vers[32];
         CSide side;
         CMode mode;
         bool audio_streaming;
         int8_t curr_vol;
     };
 
-    static_assert(sizeof(RemoteInfo) == 148);
+    static_assert(sizeof(RemoteInfo) == 180);
 
     struct EventPacket
     {

--- a/src/asha_bt.hpp
+++ b/src/asha_bt.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <etl/string.h>
+
 #include "asha_common.hpp"
 
 namespace asha 
@@ -12,6 +14,7 @@ struct AdvertisingReport {
     uint8_t   event_type;
     bd_addr_type_t  address_type;
     uint8_t   rssi;
+    etl::string<28> name;
 
     bool is_hearing_aid = false;
 

--- a/src/asha_comms.cpp
+++ b/src/asha_comms.cpp
@@ -128,6 +128,13 @@ namespace comm
         construct_and_send_packet(Type::RemInfo, unset_conn_id, remote_info);
     }
 
+    void send_advertising_packet(AdvertisingPacket const& ad_packet)
+    {
+        if (stdio_usb_connected()) {
+            construct_and_send_packet(Type::Advert, unset_conn_id, ad_packet);
+        }
+    }
+
     bool get_cmd_packet(HeaderPacket& header, CmdPacket& cmd_packet)
     {
         int ch;

--- a/src/asha_uuid.hpp
+++ b/src/asha_uuid.hpp
@@ -66,6 +66,7 @@ namespace DisUUID
     constexpr uint16_t mfgName = ORG_BLUETOOTH_CHARACTERISTIC_MANUFACTURER_NAME_STRING;
     constexpr uint16_t modelNum = ORG_BLUETOOTH_CHARACTERISTIC_MODEL_NUMBER_STRING;
     constexpr uint16_t fwVers = ORG_BLUETOOTH_CHARACTERISTIC_FIRMWARE_REVISION_STRING;
+    constexpr uint16_t swVers = ORG_BLUETOOTH_CHARACTERISTIC_SOFTWARE_REVISION_STRING;
 }
 
 inline bool uuid_eq(const uint8_t* u1, const uint8_t* u2) { return memcmp(u1, u2, sizeof(AshaUUID::service)) == 0; }

--- a/src/hearing_aid.hpp
+++ b/src/hearing_aid.hpp
@@ -122,8 +122,10 @@ struct HearingAid
     static bool is_addr_connected(const bd_addr_t addr);
     static void set_connections_allowed(bool allowed);
     static void set_audio_streaming_enabled(bool enabled);
+    static void set_auto_pair_enabled(bool enabled);
     static void start_scan();
     static void on_ad_report(const AdvertisingReport& report);
+    static void connect(const bd_addr_t addr, bd_addr_type_t addr_type);
     static void on_connected(bd_addr_t addr, hci_con_handle_t handle);
     static void on_disconnected(hci_con_handle_t handle, uint8_t status, uint8_t reason);
     static void on_data_len_set(hci_con_handle_t handle, uint16_t rx_octets, uint16_t rx_time, uint16_t tx_octets, uint16_t tx_time);
@@ -190,6 +192,7 @@ private:
 
     inline static bool connections_allowed;
     inline static bool audio_streaming_enabled;
+    inline static bool auto_pair_enabled;
 
     /* Member functions */
 

--- a/src/hearing_aid.hpp
+++ b/src/hearing_aid.hpp
@@ -58,10 +58,11 @@ struct HearingAid
         ReadMfgName         = 1U << 10,
         ReadModelNum        = 1U << 11,
         ReadFWVers          = 1U << 12,
-        ConnectL2CAP        = 1U << 13,
-        EnASPNotification   = 1U << 14,
-        Finalize            = 1U << 15,
-        Audio               = 1U << 16,
+        ReadSWVers          = 1U << 13,
+        ConnectL2CAP        = 1U << 14,
+        EnASPNotification   = 1U << 15,
+        Finalize            = 1U << 16,
+        Audio               = 1U << 17,
         Disconnect          = 1U << 29,
         Done                = 1U << 30,
         ProcessBusy         = 1U << 31
@@ -96,6 +97,7 @@ struct HearingAid
     etl::string<32> manufacturer = {};
     etl::string<32> model = {};
     etl::string<32> fw_vers = {};
+    etl::string<32> sw_vers = {};
 
     /* ASHA vars */
 
@@ -155,6 +157,7 @@ private:
             gatt_client_characteristic_t manufacture_name = {};
             gatt_client_characteristic_t model_num = {};
             gatt_client_characteristic_t fw_vers = {};
+            gatt_client_characteristic_t sw_vers = {};
         } dis = {};
 
         struct {


### PR DESCRIPTION
It is now possible to pair to hearing aids using the GUI.

When Pico-ASHA is in pairing mode and the GUI is connected, a dialog box opens and shows hearing aids which are in pairing mode. You can click the HA in the list then pair it. Once a full set is paired, pairing mode is disabled and this dialog won't show.

If the GUI does not connect within 10 seconds after startup, Pico-ASHA falls back to automatic pairing mode, like before.