### PR TITLE
Fix resume-after-silence stall and muted audio after restart

### DIFF
--- a/src/hearing_aid.cpp
+++ b/src/hearing_aid.cpp
@@ -1144,10 +1144,13 @@ void HearingAid::process_audio()
         ha->credits = l2cap_cbm_available_credits(ha->cid);
         switch (ha->audio_state) {
             case AudioState::Ready:
-                if ((!ha->other || !ha->other->stop_request_from_other) 
-                    && audio_streaming_enabled 
-                    && pcm_is_streaming 
-                    && ha->credits >= 8) {
+                // Require half the initial CoC credit window before resuming:
+                // enough headroom to start without forcing a full-window wait
+                // that can deadlock when credits idle below the ceiling.
+                if ((!ha->other || !ha->other->stop_request_from_other)
+                    && audio_streaming_enabled
+                    && pcm_is_streaming
+                    && ha->credits >= 4) {
                         ha->set_audio_busy();
                         ha->send_acp_start();
                 }

--- a/src/hearing_aid.cpp
+++ b/src/hearing_aid.cpp
@@ -1151,6 +1151,13 @@ void HearingAid::process_audio()
                     && audio_streaming_enabled
                     && pcm_is_streaming
                     && ha->credits >= 4) {
+                        // Sync curr_vol with the host volume before ACPStart so the
+                        // start payload's volume byte reflects what the host is
+                        // currently asking for. Without this, the first ACPStart
+                        // after boot carries curr_vol's class default of -128 (the
+                        // ASHA mute sentinel) and some aids latch onto that initial
+                        // value, ignoring later writes to the volume characteristic.
+                        ha->curr_vol = ha->rop.side() == Side::Left ? vol_l : vol_r;
                         ha->set_audio_busy();
                         ha->send_acp_start();
                 }


### PR DESCRIPTION
Thank you for creating Pico-ASHA! I love the design and the architecture. The way it makes use of both cores and the Pico's Bluetooth chip is really elegant.

When I tried it with my MED-EL Sonnet 3 it worked out of the box, as others have noted in #36. I only ran into two usability issues that I found annoying in everyday use. Similar problems seem to be described in #42, #47, and #48, so I hope this helps. I'll describe both issues and my fixes below. I should mention I was assisted by AI, but I reviewed the suggested fixes for plausibility and tested them manually on my Sonnet 3.

Problem 1: Audio doesn't resume after a silence-triggered stop

After a few seconds of silence the aid sends an ACPStop and drops to idle. On the next audio burst the firmware tries to send ACPStart, but only does so once L2CAP credits are ≥ 8 - an idle aid typically has fewer, so the condition never holds and audio never comes back. The only recovery is a manual Stop + Start in the GUI.

Reproduce: stream audio, pause for several seconds, resume. Audio stays silent.

Problem 2: Audio is muted after a firmware restart

`HearingAid::curr_vol` defaults to −128 (the ASHA mute sentinel). After a watchdog reset it keeps that value until the first volume update arrives from the host. If ACPStart fires before that update, the start payload carries −128 in its volume byte - and at least some aids latch onto that initial value and ignore every later write to the volume characteristic, leaving audio permanently muted.

Reproduce: hit Restart in the GUI, then play audio. Nothing comes out. Manual Stop + Start fixes it.

The suggested fixes are tiny and both live in `hearing_aid.cpp`:

- Lower the ACPStart credit threshold from 8 to 4. Four credits are enough to begin streaming and an idle-but-connected aid reliably has that many. The original 8 was probably just a conservative guess.
- Sync `curr_vol` with the live host volume right before `send_acp_start()`. This makes the start payload carry the volume the host actually wants, instead of the uninitialised −128. It mirrors what the streaming-branch volume-update path already does — it just makes sure it also happens on the very first start after boot.

These fixes were tested on a Raspberry Pi Pico 2 W with a single MED-EL Sonnet 3 (monaural). With both fixes in, Pico-ASHA is now reliable enough for practical everyday use: Audio resumes after silence, survives restarts without manual intervention, and stays at the right volume.

I hope these changes don't break anything for other hearing aids. It would be great if users with other devices could test and report back. If everything looks good, I'd love to see this merged and released.