### PR TITLE
Fix missing break after USBSettings command handling

### DIFF
--- a/src/asha_bt.cpp
+++ b/src/asha_bt.cpp
@@ -194,6 +194,7 @@ static void process_serial_cmds()
                         watchdog_enable(250, true);
                     }
                 }
+                break;
             default:
                 cmd_pkt.cmd_status = CmdStatus::CmdError;
                 break;


### PR DESCRIPTION
Without it, processed USB settings commands fall through to default and are reported as CmdError