### PR TITLE
Fix audio stutter and wedged-state cutouts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,15 @@ set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# Drop data immediately when the CDC TX buffer is full rather than stalling
+# core 1; DEADLOCK_TIMEOUT caps the mutex-wait as a secondary safety net.
+# Must precede pico_sdk_init() so the definitions reach pico_stdio_usb's
+# stdio_usb.c (target_compile_definitions on pico_asha would not).
+add_compile_definitions(
+    PICO_STDIO_USB_STDOUT_TIMEOUT_US=0
+    PICO_STDIO_DEADLOCK_TIMEOUT_MS=10
+)
+
 pico_sdk_init()
 
 message("Pico SDK version is ${PICO_SDK_VERSION_STRING}")

--- a/src/asha_bt.cpp
+++ b/src/asha_bt.cpp
@@ -159,9 +159,9 @@ static void process_serial_cmds()
         cmd_pkt.cmd_status = CmdStatus::CmdOk;
         switch (cmd_pkt.cmd) {
             case Command::HCIDump:
-                if (runtime_settings.set_hci_dump_enabled(cmd_pkt.data.enable_hci)) {
-                    //LOG_INFO("Enabling Watchdog");
-                    watchdog_enable(250, true);
+                if (runtime_settings.get_hci_dump_enabled() != cmd_pkt.data.enable_hci) {
+                    RuntimeSettings::defer_hci_dump(cmd_pkt.data.enable_hci);
+                    watchdog_enable(10, true);
                 }
                 break;
             case Command::DeletePair:
@@ -172,7 +172,7 @@ static void process_serial_cmds()
                 }
                 break;
             case Command::Restart:
-                watchdog_enable(250, true);
+                watchdog_enable(10, true);
                 break;
             case Command::AllowConnect:
                 HearingAid::set_connections_allowed(cmd_pkt.data.allow_connect);
@@ -190,8 +190,9 @@ static void process_serial_cmds()
                 {
                     USBInfo& info = cmd_pkt.data.usb_settings;
                     USBSettings settings = {.uac_version = info.uac_vers, .min_vol = info.min_vol, .max_vol = info.max_vol};
-                    if (settings && (settings != usb_settings) && runtime_settings.set_usb_settings(settings)) {
-                        watchdog_enable(250, true);
+                    if (settings && settings != runtime_settings.get_usb_settings()) {
+                        RuntimeSettings::defer_usb_settings(settings);
+                        watchdog_enable(10, true);
                     }
                 }
                 break;
@@ -246,6 +247,7 @@ void delay_start_timer_handler(btstack_timer_source_t *timer)
     if (runtime_settings.get_hci_dump_enabled() && !stdio_usb_connected()) {
         btstack_run_loop_set_timer(timer, 100);
         btstack_run_loop_add_timer(timer);
+        return;
     }
     // Set the process timer handler
     btstack_run_loop_set_timer_handler(&process_timer, &process_timer_handler);
@@ -263,7 +265,6 @@ void delay_start_timer_handler(btstack_timer_source_t *timer)
     btstack_run_loop_add_timer(&auto_pair_timer);
 
     HearingAid::start_scan();
-
 }
 
 static void hci_event_handler(PACKET_HANDLER_PARAMS)

--- a/src/asha_comms.cpp
+++ b/src/asha_comms.cpp
@@ -2,6 +2,8 @@
 #include <pico/stdio.h>
 #include <pico/stdio_usb.h>
 
+#include <tusb.h>
+
 #include <etl/circular_buffer.h>
 #include <nanocobs/cobs.h>
 
@@ -218,8 +220,15 @@ namespace comm
         cobs_encode_inc(&enc_ctx, packet, incl_len);
         cobs_encode_inc_end(&enc_ctx, &enc_len);
 
-        stdio_put_string((const char*)cobs_enc_buff, enc_len + zero_prefix, false, false);
-        stdio_flush();
+        uint32_t total = enc_len + zero_prefix;
+        // Use tud_cdc_write() directly (non-blocking) instead of stdio_put_string().
+        // stdio_put_string() spin-waits up to 1 s when the 256-byte CDC TX ring
+        // buffer is full, stalling the BTstack run loop and causing the audio
+        // timer to miss ticks → "Stream fell behind" every ~100 ms.
+        // Dropping an HCI trace packet is acceptable; stalling audio is not.
+        if (tud_cdc_write_available() < total) return;
+        tud_cdc_write(cobs_enc_buff, total);
+        tud_cdc_write_flush();
     }
 
     void send_hci_message([[maybe_unused]] int log_level, 

--- a/src/asha_comms.cpp
+++ b/src/asha_comms.cpp
@@ -220,12 +220,14 @@ namespace comm
         cobs_encode_inc(&enc_ctx, packet, incl_len);
         cobs_encode_inc_end(&enc_ctx, &enc_len);
 
+        // Write directly to CDC rather than via stdio_put_string(): the stdio
+        // path also writes to UART, where uart_putc() blocks on TX FIFO space
+        // at 115200 baud — at ~17 ms per 200-byte packet, this stalls core 1
+        // and causes the audio timer to miss ticks.
+        // This bypasses stdio_usb_mutex, creating a theoretical race if core 0
+        // calls tud_cdc_write() via stdio simultaneously. In practice core 0
+        // makes no stdio calls during audio streaming, so the risk is negligible.
         uint32_t total = enc_len + zero_prefix;
-        // Use tud_cdc_write() directly (non-blocking) instead of stdio_put_string().
-        // stdio_put_string() spin-waits up to 1 s when the 256-byte CDC TX ring
-        // buffer is full, stalling the BTstack run loop and causing the audio
-        // timer to miss ticks → "Stream fell behind" every ~100 ms.
-        // Dropping an HCI trace packet is acceptable; stalling audio is not.
         if (tud_cdc_write_available() < total) return;
         tud_cdc_write(cobs_enc_buff, total);
         tud_cdc_write_flush();

--- a/src/hearing_aid.cpp
+++ b/src/hearing_aid.cpp
@@ -1144,22 +1144,41 @@ void HearingAid::process_audio()
         ha->credits = l2cap_cbm_available_credits(ha->cid);
         switch (ha->audio_state) {
             case AudioState::Ready:
-                // Require half the initial CoC credit window before resuming:
-                // enough headroom to start without forcing a full-window wait
-                // that can deadlock when credits idle below the ceiling.
+                // After a zero-credits stop, wait up to the cooldown window for
+                // credits to fully replenish before restarting; starting at low
+                // credit counts immediately re-drains and produces audible
+                // cycling. Falls through on timeout so we don't deadlock on aids
+                // that never grant back to the ceiling.
+                if (ha->zero_credits_cooldown > 0) {
+                    --ha->zero_credits_cooldown;
+                    if (ha->credits < 8) {
+                        break;
+                    }
+                }
                 if ((!ha->other || !ha->other->stop_request_from_other)
                     && audio_streaming_enabled
                     && pcm_is_streaming
                     && ha->credits >= 4) {
-                        // Sync curr_vol with the host volume before ACPStart so the
-                        // start payload's volume byte reflects what the host is
-                        // currently asking for. Without this, the first ACPStart
-                        // after boot carries curr_vol's class default of -128 (the
-                        // ASHA mute sentinel) and some aids latch onto that initial
-                        // value, ignoring later writes to the volume characteristic.
+                        // Sync curr_vol from the host volume so the start payload
+                        // reflects what the host is currently asking for. Without
+                        // this, curr_vol's class default of -128 (the ASHA mute
+                        // sentinel) gets baked into the first start after boot and
+                        // some aids latch onto it, ignoring later volume writes.
                         ha->curr_vol = ha->rop.side() == Side::Left ? vol_l : vol_r;
                         ha->set_audio_busy();
                         ha->send_acp_start();
+                        ha->ready_stuck_ticks = 0;
+                } else if (audio_streaming_enabled && pcm_is_streaming && ha->credits < 4) {
+                    // Aid wedged with credits stuck below the start gate. Only a
+                    // fresh L2CAP CoC channel resets the credit window, so force
+                    // a reconnect once the stuck timeout elapses.
+                    if (++ha->ready_stuck_ticks >= ready_stuck_timeout_ticks) {
+                        ha->ready_stuck_ticks = 0;
+                        short_log(ha->conn_id, "%s", "Ready state stuck, reconnecting");
+                        ha->disconnect();
+                    }
+                } else {
+                    ha->ready_stuck_ticks = 0;
                 }
                 break;
             case AudioState::Streaming:
@@ -1190,6 +1209,9 @@ void HearingAid::process_audio()
                     if (ha->curr_read_index < w_index) {
                         if (ha->credits == 0) {
                             short_log(ha->conn_id, "%s", "Zero credits");
+                            // Wait long enough for a slow aid to replenish before
+                            // attempting to restart; see the Ready branch above.
+                            ha->zero_credits_cooldown = 500;
                             if (ha->other && ha->other->is_streaming()) {
                                 ha->other->stop_request_from_other = true;
                             }

--- a/src/hearing_aid.hpp
+++ b/src/hearing_aid.hpp
@@ -15,6 +15,12 @@ namespace asha
 
 constexpr int ha_process_delay_ticks = 500;
 
+// How long the audio loop is allowed to sit in Ready with the host
+// actively delivering audio but L2CAP credits stuck below the start
+// gate, before forcing a BLE reconnect to recover. Audio loop ticks
+// at 1 ms, so this is 3 seconds.
+constexpr uint32_t ready_stuck_timeout_ticks = 3000;
+
 enum class Side  {Left = 0, Right = 1};
 enum class Mode  {Mono = 0, Binaural = 1};
 enum class Codec {G722_16, G722_24};
@@ -186,6 +192,8 @@ private:
     /* L2CAP credit management */
 
     uint16_t credits = 0;
+    uint32_t zero_credits_cooldown = 0;
+    uint32_t ready_stuck_ticks = 0;
     int8_t curr_vol = -128;
 
     // Array to store current AudioControlPoint command packet

--- a/src/runtime_settings.cpp
+++ b/src/runtime_settings.cpp
@@ -1,14 +1,23 @@
 #include "runtime_settings.hpp"
 
+#include <hardware/structs/watchdog.h>
+
 #include "util.hpp"
 
 namespace asha
 {
 
+// Scratch-register encoding for deferred TLV writes across a watchdog reboot.
+// scratch[0] = command word; scratch[1..2] = packed data.
+// Scratch registers survive a watchdog reset but clear on power-on reset.
+static constexpr uint32_t SCRATCH_CMD_HCI_DUMP     = 0x41534801u; // 'A','S','H',1
+static constexpr uint32_t SCRATCH_CMD_USB_SETTINGS = 0x41534802u; // 'A','S','H',2
+
 void RuntimeSettings::init()
 {
     mutex_enter_blocking(&mtx);
     btstack_tlv_get_instance(&tlv_impl, &tlv_ctx);
+    apply_pending_scratch();
     get_settings();
     mutex_exit(&mtx);
 }
@@ -99,6 +108,47 @@ bool RuntimeSettings::set_usb_settings(USBSettings const &settings)
     }
     mutex_exit(&mtx);
     return res;
+}
+
+void RuntimeSettings::defer_hci_dump(bool enabled)
+{
+    watchdog_hw->scratch[0] = SCRATCH_CMD_HCI_DUMP;
+    watchdog_hw->scratch[1] = enabled ? 1u : 0u;
+}
+
+void RuntimeSettings::defer_usb_settings(USBSettings const& s)
+{
+    watchdog_hw->scratch[0] = SCRATCH_CMD_USB_SETTINGS;
+    // Pack uac_version (low 16 bits) and min_vol (high 16 bits) into scratch[1].
+    watchdog_hw->scratch[1] = (uint32_t)(uint16_t)s.uac_version
+                            | ((uint32_t)(uint16_t)s.min_vol << 16);
+    watchdog_hw->scratch[2] = (uint32_t)(uint16_t)s.max_vol;
+}
+
+// Called from init() after btstack_tlv_get_instance(), before get_settings().
+// Writes any deferred setting to TLV so get_settings() picks it up normally.
+void RuntimeSettings::apply_pending_scratch()
+{
+    switch (watchdog_hw->scratch[0]) {
+    case SCRATCH_CMD_HCI_DUMP: {
+        bool enabled = watchdog_hw->scratch[1] != 0u;
+        store_tlv_tag(Tag::HCIDump, enabled);
+        break;
+    }
+    case SCRATCH_CMD_USB_SETTINGS: {
+        USBSettings s;
+        s.uac_version = (uint16_t)(watchdog_hw->scratch[1] & 0xFFFFu);
+        s.min_vol     = (int16_t)(watchdog_hw->scratch[1] >> 16);
+        s.max_vol     = (int16_t)(watchdog_hw->scratch[2] & 0xFFFFu);
+        store_tlv_tag(Tag::USBSetting, s);
+        break;
+    }
+    default:
+        break;
+    }
+    watchdog_hw->scratch[0] = 0u;
+    watchdog_hw->scratch[1] = 0u;
+    watchdog_hw->scratch[2] = 0u;
 }
 
 } // namespace asha

--- a/src/runtime_settings.cpp
+++ b/src/runtime_settings.cpp
@@ -8,7 +8,11 @@ namespace asha
 {
 
 // Scratch-register encoding for deferred TLV writes across a watchdog reboot.
-// scratch[0] = command word; scratch[1..2] = packed data.
+// scratch[0] = command word; scratch[1] = packed data (both commands).
+// HCI dump:     scratch[1] bit 0 = enabled flag.
+// USB settings: scratch[1] bits  0-13 = (min_vol - ASHA_USB_VOL_MIN),
+//               scratch[1] bits 14-27 = (max_vol - ASHA_USB_VOL_MIN),
+//               scratch[1] bit  28    = (uac_version - 1).
 // Scratch registers survive a watchdog reset but clear on power-on reset.
 static constexpr uint32_t SCRATCH_CMD_HCI_DUMP     = 0x41534801u; // 'A','S','H',1
 static constexpr uint32_t SCRATCH_CMD_USB_SETTINGS = 0x41534802u; // 'A','S','H',2
@@ -119,10 +123,10 @@ void RuntimeSettings::defer_hci_dump(bool enabled)
 void RuntimeSettings::defer_usb_settings(USBSettings const& s)
 {
     watchdog_hw->scratch[0] = SCRATCH_CMD_USB_SETTINGS;
-    // Pack uac_version (low 16 bits) and min_vol (high 16 bits) into scratch[1].
-    watchdog_hw->scratch[1] = (uint32_t)(uint16_t)s.uac_version
-                            | ((uint32_t)(uint16_t)s.min_vol << 16);
-    watchdog_hw->scratch[2] = (uint32_t)(uint16_t)s.max_vol;
+    watchdog_hw->scratch[1] =
+          (uint32_t)(s.min_vol - ASHA_USB_VOL_MIN)          // bits 0-13
+        | ((uint32_t)(s.max_vol - ASHA_USB_VOL_MIN) << 14)  // bits 14-27
+        | ((uint32_t)(s.uac_version - 1u) << 28);           // bit 28
 }
 
 // Called from init() after btstack_tlv_get_instance(), before get_settings().
@@ -136,10 +140,11 @@ void RuntimeSettings::apply_pending_scratch()
         break;
     }
     case SCRATCH_CMD_USB_SETTINGS: {
+        uint32_t p = watchdog_hw->scratch[1];
         USBSettings s;
-        s.uac_version = (uint16_t)(watchdog_hw->scratch[1] & 0xFFFFu);
-        s.min_vol     = (int16_t)(watchdog_hw->scratch[1] >> 16);
-        s.max_vol     = (int16_t)(watchdog_hw->scratch[2] & 0xFFFFu);
+        s.min_vol     = (int16_t)(p & 0x3FFFu) + ASHA_USB_VOL_MIN;
+        s.max_vol     = (int16_t)((p >> 14) & 0x3FFFu) + ASHA_USB_VOL_MIN;
+        s.uac_version = (uint16_t)((p >> 28) & 1u) + 1u;
         store_tlv_tag(Tag::USBSetting, s);
         break;
     }
@@ -148,7 +153,6 @@ void RuntimeSettings::apply_pending_scratch()
     }
     watchdog_hw->scratch[0] = 0u;
     watchdog_hw->scratch[1] = 0u;
-    watchdog_hw->scratch[2] = 0u;
 }
 
 } // namespace asha

--- a/src/runtime_settings.hpp
+++ b/src/runtime_settings.hpp
@@ -31,6 +31,13 @@ struct RuntimeSettings
     bool set_full_set_paired(bool have_full_set);
     bool set_usb_settings(USBSettings const& settings);
 
+    // Store a pending setting in watchdog scratch registers so it can be
+    // written to TLV after the watchdog reboot, avoiding a race between the
+    // watchdog countdown and BTstack's own TLV writes.  Call immediately
+    // before watchdog_enable().
+    static void defer_hci_dump(bool enabled);
+    static void defer_usb_settings(USBSettings const& settings);
+
     explicit operator bool();
 
 private:
@@ -53,6 +60,7 @@ private:
     mutex_t mtx = {};
 
     void get_settings();
+    void apply_pending_scratch();
 
     template <typename T>
     bool get_tlv_tag(enum Tag tag, T& var) 


### PR DESCRIPTION
This is a follow-up to #52. After that fix, some users have reported occasional lag/dropouts during streaming. This PR addresses two distinct issues that surfaced when testing on a regular Pico W (not the Pico 2 W used last time) - may idea was that the problem might be easier to reproduce on the older board.

**Stutter / crackling during playback:**

When L2CAP CoC credits drained to zero mid-stream, the audio loop would immediately retry ACPStop → ACPStart. On aids slow to grant credits back (tested with MED-EL Sonnet 3), the restart drained the channel again within seconds, producing a rapid stop/start cycle (~10 Hz) audible as crackling, sometimes with `GATT_CLIENT_IN_WRONG_STATE` errors interleaved when the GATT layer couldn't keep up.

Fix: a 500 ms cooldown after zero-credits stops. During the cooldown the audio loop waits for credits to fully replenish to the initial CoC window (8) before restarting. If 8 isn't reached in time, falls through to the existing >= 4 start gate so it can't deadlock on aids that never grant back to the ceiling.

**Audio dies, only Restart recovered:**

Less common but more disruptive: after some time, the aid would wedge: credits stuck below the start gate, no audio reaching the aid, GUI Restart the only known recovery.

Fix: detect the stuck state (host delivering audio, but credits stuck below the gate for >3 s) and force a BLE disconnect. The auto-reconnect path then re-establishes the link with a fresh L2CAP channel: credits reset to 8, audio resumes in ~1 s, no user intervention needed.

The 3 s threshold was calibrated empirically (using the MED-EL Sonnet 3 again): across a varied-use session covering many normal recoveries (silence-stops, zero-credits clusters, low-credit transients), the longest observed non-wedge stuck duration was <1 s, leaving 3× margin.

Again, I used Claude Code heavily to help with debugging and code fixes.

@shermp @mviereck @peter6005 please check if these changes make sense to you and improve stability with your devices.