### PR TITLE
Fixes discovery of devices advertising ASHA via Service Data

### DIFF
--- a/src/asha_bt.cpp
+++ b/src/asha_bt.cpp
@@ -395,6 +395,12 @@ void AdvertisingReport::check_if_ha(uint8_t length, const uint8_t * data)
                 }
             }
             break;
+        case BLUETOOTH_DATA_TYPE_SERVICE_DATA_16_BIT_UUID:
+            if (size >= 2 && little_endian_read_16(adv_data, 0) == AshaUUID::service16) {
+                //LOG_SCAN("ASHA 16 bit service data discovered");
+                is_hearing_aid = true;
+            }
+            break;
         case BLUETOOTH_DATA_TYPE_SHORTENED_LOCAL_NAME:
         case BLUETOOTH_DATA_TYPE_COMPLETE_LOCAL_NAME:
             name.clear();


### PR DESCRIPTION
Fixes #56 (MED-EL Rondo 3 and AudioStream adapter never discovered).

The adapter advertises the ASHA service UUID (`0xFDF0`) via AD type `0x16`
(Service Data - 16-bit UUID) rather than a UUID list. `check_if_ha` had no
`case` for this AD type, so the device was silently ignored.

Adds the missing `BLUETOOTH_DATA_TYPE_SERVICE_DATA_16_BIT_UUID` case to the
`switch` in `AdvertisingReport::check_if_ha`.

