### PR TITLE
Refactor characteristic discovery & reading; audio & process timers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,15 +34,6 @@ jobs:
                 ref: "${{ env.PICO_SDK_COMMIT_HASH }}"
                 fetch-depth: "0"
 
-            - name: Checkout TinyUSB
-              uses: actions/checkout@v6
-              with:
-                repository: hathach/tinyusb
-                path: tinyusb
-                submodules: recursive
-                ref: "${{ env.TINYUSB_TAG }}"
-                fetch-depth: "0"
-
             - name: Install dependencies
               run: |
                 sudo apt-get update && sudo apt-get -y install cmake gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib
@@ -53,7 +44,6 @@ jobs:
                 cd pico-asha/build/${{ matrix.board }}
                 cmake \
                   -DPICO_SDK_PATH=${{github.workspace}}/pico-sdk \
-                  -DPICO_TINYUSB_PATH=${{github.workspace}}/tinyusb \
                   -DCMAKE_BUILD_TYPE=MinSizeRel \
                   -DPICO_BOARD=${{ matrix.board }} \
                   ../..

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,20 @@ set(PICO_BOARD pico_w CACHE STRING "Board type")
 
 cmake_minimum_required(VERSION 3.13)
 
+# Get External projects here before importing the SDK
+Include(FetchContent)
+
+# TinyUSB 0.20.0
+FetchContent_Declare(
+  tinyusb
+  GIT_REPOSITORY https://github.com/hathach/tinyusb
+  GIT_TAG        3af1bec1a9161ee8dec29487831f7ac7ade9e189
+)
+FetchContent_MakeAvailable(tinyusb)
+
+SET(PICO_TINYUSB_PATH "${tinyusb_SOURCE_DIR}")
+
+
 SET(CMAKE_CXX_FLAGS_RELEASE "-O2")
 SET(CMAKE_C_FLAGS_RELEASE "-O2")
 
@@ -43,8 +57,6 @@ message("Pico SDK version is ${PICO_SDK_VERSION_STRING}")
 if(PICO_SDK_VERSION_STRING VERSION_LESS "2.2.0")
   message( FATAL_ERROR "Pico SDK version must be 2.2.0 or greater" )
 endif()
-
-Include(FetchContent)
 
 FetchContent_Declare(
   etl

--- a/src/asha_bt.cpp
+++ b/src/asha_bt.cpp
@@ -45,11 +45,9 @@ static gatt_client_notification_t notification_listener = {};
 
 static void hci_event_handler(PACKET_HANDLER_PARAMS);
 
-constexpr btstack_time_t ha_process_interval_ms = 2;
-static btstack_timer_source_t process_timer = {};
-static void process_timer_handler(btstack_timer_source_t * timer);
 
 constexpr btstack_time_t ha_audio_interval_ms = 1;
+static int process_delay = 0;
 static btstack_timer_source_t audio_timer = {};
 
 static hci_dump_t pa_hci_dump_impl = {
@@ -204,10 +202,21 @@ static void process_serial_cmds()
     }
 }
 
-static void process_timer_handler(btstack_timer_source_t* timer)
+static void audio_timer_handler(btstack_timer_source_t* timer)
 {
-    btstack_run_loop_set_timer(timer, ha_process_interval_ms);
+    btstack_run_loop_set_timer(timer, ha_audio_interval_ms);
     btstack_run_loop_add_timer(timer);
+
+    // First process audio
+    if (HearingAid::process_audio()) {
+        // if audio is sent to HA, delay other processing
+        process_delay = 5;
+    }
+
+    if (process_delay > 0) {
+        --process_delay;
+        return;
+    }
 
     process_serial_cmds();
     if (stdio_usb_connected()) {
@@ -223,14 +232,6 @@ static void process_timer_handler(btstack_timer_source_t* timer)
         comm::try_send_events();
     }
     HearingAid::process();
-}
-
-static void audio_timer_handler(btstack_timer_source_t* timer)
-{
-    btstack_run_loop_set_timer(timer, ha_audio_interval_ms);
-    btstack_run_loop_add_timer(timer);
-
-    HearingAid::process_audio();
 }
 
 static void auto_pair_timer_handler([[maybe_unused]] btstack_timer_source_t * timer)
@@ -249,10 +250,6 @@ void delay_start_timer_handler(btstack_timer_source_t *timer)
         btstack_run_loop_add_timer(timer);
         return;
     }
-    // Set the process timer handler
-    btstack_run_loop_set_timer_handler(&process_timer, &process_timer_handler);
-    btstack_run_loop_set_timer(&process_timer, ha_process_interval_ms);
-    btstack_run_loop_add_timer(&process_timer);
 
     // Set the audio timer handler
     btstack_run_loop_set_timer_handler(&audio_timer, &audio_timer_handler);

--- a/src/hearing_aid.cpp
+++ b/src/hearing_aid.cpp
@@ -964,7 +964,7 @@ void HearingAid::handle_gatt_notification(PACKET_HANDLER_PARAMS)
                 case ASPStatus::ok:
                     if (ha->audio_state == AudioState::Start) {
                         //LOG_INFO("%s: Audio start OK", ha->get_side_str());
-                        add_event_to_buffer(ha->conn_id, EventPacket(EventType::ASPStart));
+                        // add_event_to_buffer(ha->conn_id, EventPacket(EventType::ASPStart));
                         ha->audio_state = AudioState::Streaming;
                         asha_audio_set_encoding_enabled(true);
                         if (ha->other && ha->other->is_streaming()) {
@@ -973,7 +973,7 @@ void HearingAid::handle_gatt_notification(PACKET_HANDLER_PARAMS)
                         ha->first_audio_send = true;
                     } else if (ha->audio_state == AudioState::Stop) {
                         //LOG_INFO("%s: Audio stop OK", ha->get_side_str());
-                        add_event_to_buffer(ha->conn_id, EventPacket(EventType::ASPStop));
+                        // add_event_to_buffer(ha->conn_id, EventPacket(EventType::ASPStop));
 
                         ha->stop_request_from_other = false;
                         ha->audio_state = AudioState::Ready;
@@ -1074,7 +1074,7 @@ bool HearingAid::process_audio()
                     int8_t v = ha->rop.side() == Side::Left ? vol_l : vol_r;
                     if (ha->curr_vol != v) {
                         ha->curr_vol = v;
-                        short_log(ha->conn_id, "USB L:%d R:%d", (int)usb_vol_l, (int)usb_vol_r);
+                        // short_log(ha->conn_id, "USB L:%d R:%d", (int)usb_vol_l, (int)usb_vol_r);
                         ha->send_volume(ha->curr_vol);
                     }
                     if (w_index == 0) {

--- a/src/hearing_aid.cpp
+++ b/src/hearing_aid.cpp
@@ -999,7 +999,7 @@ void HearingAid::handle_gatt_notification(PACKET_HANDLER_PARAMS)
     }
 }
 
-void HearingAid::process_audio()
+bool HearingAid::process_audio()
 {
     using namespace comm;
 
@@ -1014,6 +1014,8 @@ void HearingAid::process_audio()
     bool pcm_is_streaming = asha_audio_get_pcm_streaming_enabled();
 
     asha_audio_set_encode_mono(!(hearing_aids[0]->is_streaming() && hearing_aids[1]->is_streaming()));
+
+    bool enable_process_delay = false;
 
     for (auto ha : hearing_aids) {
         if (ha->process_state != ProcessState::Audio) { continue; }
@@ -1111,6 +1113,7 @@ void HearingAid::process_audio()
                         ha->audio_data = asha_audio_get_encoded_at_index(audio_side, ha->curr_read_index);
                         ++(ha->curr_read_index);
                         l2cap_request_can_send_now_event(ha->cid);
+                        enable_process_delay = true;
                     }
                 }
                 break;
@@ -1118,6 +1121,7 @@ void HearingAid::process_audio()
                 break;
         }
     }
+    return enable_process_delay;
 }
 
 /* Private methods */

--- a/src/hearing_aid.cpp
+++ b/src/hearing_aid.cpp
@@ -11,7 +11,7 @@ namespace asha
 /* Data length variables */
 static constexpr uint16_t pdu_len = 167u;
 
-static constexpr uint16_t max_tx_time = 1064;
+static constexpr uint16_t max_tx_time = (pdu_len + 14) * 8;
 
 static constexpr size_t ev_packet_str_size = sizeof comm::EventPacket::data.str;
 
@@ -549,7 +549,7 @@ void HearingAid::handle_sm(PACKET_HANDLER_PARAMS)
                 case ERROR_CODE_SUCCESS:
                     //LOG_INFO("%s: Pairing complete", ha->get_side_str());;
                     ha->paired_and_bonded = true;
-                    ha->process_state = ha->cached ? ProcessState::ReadPSM : ProcessState::DiscoverASHAChar;
+                    ha->process_state = ProcessState::DataLength;
                     add_event_to_buffer(ha->conn_id, EventPacket(EventType::PairAndBond));
                     break;
                 case ERROR_CODE_CONNECTION_TIMEOUT:
@@ -597,7 +597,7 @@ void HearingAid::handle_sm(PACKET_HANDLER_PARAMS)
                 case ERROR_CODE_SUCCESS:
                     //LOG_INFO("%s: Reencryption succeeded", ha->get_side_str());
                     ha->paired_and_bonded = true;
-                    ha->process_state = ha->cached ? ProcessState::ReadPSM : ProcessState::DiscoverASHAChar;
+                    ha->process_state = ProcessState::DataLength;
                     comm::add_event_to_buffer(ha->conn_id, EventPacket(EventType::PairAndBond));
                     break;
                 case ERROR_CODE_PIN_OR_KEY_MISSING:

--- a/src/hearing_aid.cpp
+++ b/src/hearing_aid.cpp
@@ -115,76 +115,22 @@ void HearingAid::process()
                 ha->set_process_busy();
                 ha->set_data_langth();
                 break;
-            case DiscoverASHAChar:
-                //LOG_INFO("%s: Discovering ASHA characteristics", ha->get_side_str());
-                ev_type = EventType::DiscASHAChar;
+            case DiscoverChars: {
                 ha->set_process_busy();
-                res = gatt_client_discover_characteristics_for_service(&HearingAid::handle_char_discovery, ha->conn_handle, &ha->services.asha.service);
+                auto i = ha->service_index++; // Yes, the post-increment is on purpose
+                auto s = ha->service_arr[i];
+                ev_type = ha->service_ev_arr[i];
+                res = gatt_client_discover_characteristics_for_service(&HearingAid::handle_char_discovery, ha->conn_handle, s);
                 break;
-            case ReadROP:
-                ev_type = EventType::ROPRead;
-                //LOG_INFO("%s: Read ROP characteristic", ha->get_side_str());
+            }
+            case ReadChars: {
                 ha->set_process_busy();
-                res = gatt_client_read_value_of_characteristic(&HearingAid::handle_char_read, ha->conn_handle, &ha->services.asha.rop);
+                auto i = ha->chars_index++; // Yes, the post-increment is on purpose
+                auto c = ha->chars_arr[i];
+                ev_type = ha->chars_ev_arr[i];
+                res = gatt_client_read_value_of_characteristic(&HearingAid::handle_char_read, ha->conn_handle, c);
                 break;
-            case ReadPSM:
-                ev_type = EventType::PSMRead;
-                //LOG_INFO("%s: Read PSM", ha->get_side_str());
-                ha->set_process_busy();
-                res = gatt_client_read_value_of_characteristic(&HearingAid::handle_char_read, ha->conn_handle, &ha->services.asha.psm);
-                break;
-            case DiscoverGAPChar:
-                ev_type = EventType::DiscGAPChar;
-                //LOG_INFO("%s: Discover GAP characteristics", ha->get_side_str());
-                ha->set_process_busy();
-                res = gatt_client_discover_characteristics_for_service(&HearingAid::handle_char_discovery, ha->conn_handle, &ha->services.gap.service);
-                break;
-            case ReadDeviceName:
-                ev_type = EventType::DevNameRead;
-                //LOG_INFO("%s: Read device name", ha->get_side_str());
-                ha->set_process_busy();
-                res = gatt_client_read_value_of_characteristic(&HearingAid::handle_char_read, ha->conn_handle, &ha->services.gap.device_name);
-                break;
-            case DiscoverDISChar:
-                ev_type = EventType::DiscDISChar;
-                //LOG_INFO("%s: Discover DIS characteristics", ha->get_side_str());
-                ha->set_process_busy();
-                res = gatt_client_discover_characteristics_for_service(&HearingAid::handle_char_discovery, ha->conn_handle, &ha->services.dis.service);
-                break;
-            case ReadMfgName:
-                ev_type = EventType::MfgRead;
-                //LOG_INFO("%s: Read manufacturer name", ha->get_side_str());
-                ha->set_process_busy();
-                res = gatt_client_read_value_of_characteristic(&HearingAid::handle_char_read, ha->conn_handle, &ha->services.dis.manufacture_name);
-                break;
-            case ReadModelNum:
-                ev_type = EventType::ModelRead;
-                //LOG_INFO("%s: Read model number", ha->get_side_str());
-                ha->set_process_busy();
-                res = gatt_client_read_value_of_characteristic(&HearingAid::handle_char_read, ha->conn_handle, &ha->services.dis.model_num);
-                break;
-            case ReadFWVers:
-                ev_type = EventType::FWRead;
-                //LOG_INFO("%s: Read FW version", ha->get_side_str());
-                ha->set_process_busy();
-                res = gatt_client_read_value_of_characteristic(&HearingAid::handle_char_read, ha->conn_handle, &ha->services.dis.fw_vers);
-                break;
-            case ReadSWVers:
-                ev_type = EventType::SWRead;
-                //LOG_INFO("%s: Read FW version", ha->get_side_str());
-                ha->set_process_busy();
-                res = gatt_client_read_value_of_characteristic(&HearingAid::handle_char_read, ha->conn_handle, &ha->services.dis.sw_vers);
-                break;
-            case DiscoverMFIChar:
-                ev_type = EventType::DiscMFIChar;
-                ha->set_process_busy();
-                res = gatt_client_discover_characteristics_for_service(&HearingAid::handle_char_discovery, ha->conn_handle, &ha->services.mfi.service);
-                break;
-            case ReadBattery:
-                ev_type = EventType::MfiBatteryRead;
-                ha->set_process_busy();
-                res = gatt_client_read_value_of_characteristic(&HearingAid::handle_char_read, ha->conn_handle, &ha->services.mfi.battery);
-                break;
+            }
             case ConnectL2CAP:
                 ev_type = EventType::L2CAPCon;
                 //LOG_INFO("%s: Create L2CAP CoC", ha->get_side_str());
@@ -484,8 +430,7 @@ void HearingAid::on_data_len_set(hci_con_handle_t handle,
     // LOG_INFO("%s: DL set to: RX Octets: %hu, RX Time: %hu us, TX Octets: %hu, TX Time: %hu us",
     //                     ha->get_side_str(),
     //                     rx_octets, rx_time, tx_octets, tx_time);    
-    
-    ha->process_state = ha->cached ? ProcessState::ReadPSM : ProcessState::DiscoverASHAChar;
+    ha->process_state = ProcessState::DiscoverChars;
 }
 
 void HearingAid::delete_pair()
@@ -747,41 +692,18 @@ void HearingAid::handle_char_discovery(PACKET_HANDLER_PARAMS)
             att_status = gatt_event_query_complete_get_att_status(packet);
             ha = get_by_con_handle(handle);
 
-            switch (ha->process_state) {
-                case DiscoverASHAChar | ProcessBusy:
-                    if (att_status != ATT_ERROR_SUCCESS) {
-                        //LOG_ERROR("%s: Error discovering ASHA characteristics: %s", ha->get_side_str(), att_err_str(att_status));
-                        add_event_to_buffer(ha->conn_id, EventPacket(EventType::DiscASHAChar, StatusType::ATTStatus, att_status));
-                        ha->disconnect();
-                    } else {
-                        ha->process_state = ReadROP;
-                    }
+            if (att_status != ATT_ERROR_SUCCESS) {
+                auto ev_type = ha->service_ev_arr[ha->service_index - 1];
+                add_event_to_buffer(ha->conn_id, EventPacket(ev_type, StatusType::ATTStatus, att_status));
+                if (ev_type == EventType::DiscASHAChar) {
+                    ha->disconnect();
                     break;
-                case DiscoverGAPChar | ProcessBusy:
-                    if (att_status != ATT_ERROR_SUCCESS) {
-                        //LOG_ERROR("%s: Error discovering GAP characteristics: %s", ha->get_side_str(), att_err_str(att_status));
-                        add_event_to_buffer(ha->conn_id, EventPacket(EventType::DiscGAPChar, StatusType::ATTStatus, att_status));
-                        // Not a fatal error
-                    }
-                    ha->process_state = ReadDeviceName;
-                    break;
-                case DiscoverDISChar | ProcessBusy:
-                    if (att_status != ATT_ERROR_SUCCESS) {
-                        //LOG_ERROR("%s: Error discovering DIS characteristics: %s", ha->get_side_str(), att_err_str(att_status));
-                        add_event_to_buffer(ha->conn_id, EventPacket(EventType::DiscDISChar, StatusType::ATTStatus, att_status));
-                        // Not a fatal error
-                    }
-                    ha->process_state = ReadMfgName;
-                    break;
-                case DiscoverMFIChar | ProcessBusy:
-                    if (att_status != ATT_ERROR_SUCCESS) {
-                        add_event_to_buffer(ha->conn_id, EventPacket(EventType::DiscMFIChar, StatusType::ATTStatus, att_status));
-                        // Not a fatal error
-                    }
-                    ha->process_state = ReadBattery;
-                    break;
-                default:
-                    break;
+                }
+            }
+            if (ha->service_index < ha->service_arr.size()) {
+                ha->process_state = DiscoverChars;
+            } else {
+                ha->process_state = ReadChars;
             }
             break;
     }
@@ -838,112 +760,66 @@ void HearingAid::handle_char_read(PACKET_HANDLER_PARAMS)
                 ha->battery_level = val[0];
             }
             break;
-        case GATT_EVENT_QUERY_COMPLETE:
+
+        case GATT_EVENT_QUERY_COMPLETE: {
             handle = gatt_event_query_complete_get_handle(packet);
             att_status = gatt_event_query_complete_get_att_status(packet);
             ha = get_by_con_handle(handle);
 
-            switch (ha->process_state) {
-                case ReadROP | ProcessBusy:
-                    if (att_status != ATT_ERROR_SUCCESS) {
-                        //LOG_ERROR("%s: Error reading ROP characteristic: %s", ha->get_side_str(), att_err_str(att_status));
-                        add_event_to_buffer(ha->conn_id, EventPacket(EventType::ROPRead, StatusType::ATTStatus, att_status));
-                        ha->disconnect();
-                    } else {
-                        EventPacket ev_pkt(EventType::ROPRead);
-                        memcpy(ev_pkt.data.rop, ha->rop.raw_data, sizeof ev_pkt.data.rop);
-                        add_event_to_buffer(ha->conn_id, ev_pkt);
-                        ha->process_state = ReadPSM;
-                    }
+            auto ev_type = ha->chars_ev_arr[ha->chars_index - 1];
+
+            if (att_status != ATT_ERROR_SUCCESS) {
+                add_event_to_buffer(ha->conn_id, EventPacket(ev_type, StatusType::ATTStatus, att_status));
+                if (ev_type == EventType::ROPRead || ev_type == EventType::PSMRead) {
+                    ha->disconnect();
                     break;
-                case ReadPSM | ProcessBusy:
-                    if (att_status != ATT_ERROR_SUCCESS) {
-                        //LOG_ERROR("%s: Error reading PSM characteristics %s", ha->get_side_str(), att_err_str(att_status));
-                        add_event_to_buffer(ha->conn_id, EventPacket(EventType::PSMRead, StatusType::ATTStatus, att_status));
-                        ha->disconnect();
-                    } else {
-                        EventPacket ev_pkt(EventType::PSMRead);
-                        ev_pkt.data.psm = ha->psm;
-                        add_event_to_buffer(ha->conn_id, ev_pkt);
-                        ha->process_state = ha->cached ? ReadBattery : DiscoverGAPChar;
-                    }
+                }
+            }
+            EventPacket ev_pkt(ev_type);
+            switch (ev_type) {
+                case EventType::ROPRead:
+                    memcpy(ev_pkt.data.rop, ha->rop.raw_data, sizeof ev_pkt.data.rop);
+                    add_event_to_buffer(ha->conn_id, ev_pkt);
                     break;
-                case ReadDeviceName | ProcessBusy:
-                    if (att_status != ATT_ERROR_SUCCESS) {
-                        //LOG_ERROR("%s: Error reading device name characteristic: %s", ha->get_side_str(), att_err_str(att_status));
-                        add_event_to_buffer(ha->conn_id, EventPacket(EventType::DevNameRead, StatusType::ATTStatus, att_status));
-                        // Not a fatal error
-                    } else {
-                        EventPacket ev_pkt(EventType::DevNameRead);
-                        ev_pkt.set_data_str("%s", ha->device_name.c_str());
-                        add_event_to_buffer(ha->conn_id, ev_pkt);
-                    }
-                    ha->process_state = DiscoverDISChar;
+                case EventType::PSMRead:
+                    ev_pkt.data.psm = ha->psm;
+                    add_event_to_buffer(ha->conn_id, ev_pkt);
                     break;
-                case ReadMfgName | ProcessBusy:
-                    if (att_status != ATT_ERROR_SUCCESS) {
-                        //LOG_ERROR("%s: Error reading manufacturer name characteristic: %s", ha->get_side_str(), att_err_str(att_status));
-                        add_event_to_buffer(ha->conn_id, EventPacket(EventType::MfgRead, StatusType::ATTStatus, att_status));
-                        // Not a fatal error
-                    } else {
-                        EventPacket ev_pkt(EventType::MfgRead);
-                        ev_pkt.set_data_str("%s", ha->manufacturer.c_str());
-                        add_event_to_buffer(ha->conn_id, ev_pkt);
-                    }
-                    ha->process_state = ReadModelNum;
+                case EventType::DevNameRead:
+                    ev_pkt.set_data_str("%s", ha->device_name.c_str());
+                    add_event_to_buffer(ha->conn_id, ev_pkt);
                     break;
-                case ReadModelNum | ProcessBusy:
-                    if (att_status != ATT_ERROR_SUCCESS) {
-                        //LOG_ERROR("%s: Error reading model number characteristic: %s", ha->get_side_str(), att_err_str(att_status));
-                        add_event_to_buffer(ha->conn_id, EventPacket(EventType::ModelRead, StatusType::ATTStatus, att_status));
-                        // Not a fatal error
-                    } else {
-                        EventPacket ev_pkt(EventType::ModelRead);
-                        ev_pkt.set_data_str("%s", ha->model.c_str());
-                        add_event_to_buffer(ha->conn_id, ev_pkt);
-                    }
-                    ha->process_state = ReadFWVers;
+                case EventType::MfgRead:
+                    ev_pkt.set_data_str("%s", ha->manufacturer.c_str());
+                    add_event_to_buffer(ha->conn_id, ev_pkt);
                     break;
-                case ReadFWVers | ProcessBusy:
-                    if (att_status != ATT_ERROR_SUCCESS) {
-                        //LOG_ERROR("%s: Error reading FW version characteristic: %s", ha->get_side_str(), att_err_str(att_status));
-                        add_event_to_buffer(ha->conn_id, EventPacket(EventType::FWRead, StatusType::ATTStatus, att_status));
-                        // Not a fatal error
-                    } else {
-                        EventPacket ev_pkt(EventType::FWRead);
-                        ev_pkt.set_data_str("%s", ha->fw_vers.c_str());
-                        add_event_to_buffer(ha->conn_id, ev_pkt);
-                    }
-                    ha->process_state = ReadSWVers;
+                case EventType::ModelRead:
+                    ev_pkt.set_data_str("%s", ha->model.c_str());
+                    add_event_to_buffer(ha->conn_id, ev_pkt);
                     break;
-                case ReadSWVers | ProcessBusy:
-                    if (att_status != ATT_ERROR_SUCCESS) {
-                        //LOG_ERROR("%s: Error reading FW version characteristic: %s", ha->get_side_str(), att_err_str(att_status));
-                        add_event_to_buffer(ha->conn_id, EventPacket(EventType::SWRead, StatusType::ATTStatus, att_status));
-                        // Not a fatal error
-                    } else {
-                        EventPacket ev_pkt(EventType::SWRead);
-                        ev_pkt.set_data_str("%s", ha->sw_vers.c_str());
-                        add_event_to_buffer(ha->conn_id, ev_pkt);
-                    }
-                    ha->process_state = DiscoverMFIChar;
+                case EventType::FWRead:
+                    ev_pkt.set_data_str("%s", ha->fw_vers.c_str());
+                    add_event_to_buffer(ha->conn_id, ev_pkt);
                     break;
-                case ReadBattery | ProcessBusy:
-                    if (att_status != ATT_ERROR_SUCCESS) {
-                        //LOG_ERROR("%s: Error reading FW version characteristic: %s", ha->get_side_str(), att_err_str(att_status));
-                        add_event_to_buffer(ha->conn_id, EventPacket(EventType::MfiBatteryRead, StatusType::ATTStatus, att_status));
-                        // Not a fatal error
-                    } else {
-                        EventPacket ev_pkt(EventType::MfiBatteryRead);
-                        ev_pkt.data.battery_level = ha->battery_level;
-                        add_event_to_buffer(ha->conn_id, ev_pkt);
-                    }
-                    ha->process_state = ConnectL2CAP;
+                case EventType::SWRead:
+                    ev_pkt.set_data_str("%s", ha->sw_vers.c_str());
+                    add_event_to_buffer(ha->conn_id, ev_pkt);
+                    break;
+                case EventType::MfiBatteryRead:
+                    ev_pkt.data.battery_level = ha->battery_level;
+                    add_event_to_buffer(ha->conn_id, ev_pkt);
                     break;
                 default:
                     break;
             }
+
+            if (ha->chars_index < ha->chars_arr.size()) {
+                ha->process_state = ReadChars;
+            } else {
+                ha->process_state = ConnectL2CAP;
+            }
             break;
+        }
         default:
             break;
     }
@@ -1461,6 +1337,9 @@ void HearingAid::reset()
     paired_and_bonded = false;
     process_delay_ticks = 0;
     error_count = 0;
+    service_index = 0;
+    chars_index = cached_chars_index;
+    
     if (!cached) {
         memset(addr, 0U, sizeof(bd_addr_t));
         device_name.clear();
@@ -1471,6 +1350,7 @@ void HearingAid::reset()
         rop = {};
         side_str = "Unknown";
         services = {};
+        chars_index = 0;
     }
 }
 

--- a/src/hearing_aid.cpp
+++ b/src/hearing_aid.cpp
@@ -112,8 +112,15 @@ void HearingAid::process()
             case DataLength:
                 ev_type = EventType::DLE;
                 //LOG_INFO("%s: Setting data length",  ha->get_side_str())
-                ha->set_process_busy();
+                // If the controller can't take the command yet, yield and retry on
+                // the next tick rather than spinning the run loop. Advance to
+                // discovery right after sending: the controller only emits
+                // HCI_SUBEVENT_LE_DATA_LENGTH_CHANGE when the effective length
+                // actually changes, so an aid already at the requested size would
+                // never fire it and we'd stall waiting.
+                if (!hci_can_send_command_packet_now()) { break; }
                 ha->set_data_langth();
+                ha->process_state = DiscoverChars;
                 break;
             case DiscoverChars: {
                 ha->set_process_busy();
@@ -424,13 +431,14 @@ void HearingAid::on_data_len_set(hci_con_handle_t handle,
 {
     HearingAid* ha = get_by_con_handle(handle);
 
-    // The data length is automatically changed when DLE is enabled, so ignore that case
-    if (ha->process_state != (ProcessState::DataLength | ProcessState::ProcessBusy)) { return; }
-
+    // DLE changes are handled asynchronously: the DataLength process state issues
+    // the set-data-length command and advances to DiscoverChars itself, rather than
+    // waiting on this event (which the controller doesn't emit when the effective
+    // data length is unchanged). This handler is now informational only.
+    (void)ha;
     // LOG_INFO("%s: DL set to: RX Octets: %hu, RX Time: %hu us, TX Octets: %hu, TX Time: %hu us",
     //                     ha->get_side_str(),
-    //                     rx_octets, rx_time, tx_octets, tx_time);    
-    ha->process_state = ProcessState::DiscoverChars;
+    //                     rx_octets, rx_time, tx_octets, tx_time);
 }
 
 void HearingAid::delete_pair()
@@ -1236,12 +1244,7 @@ void HearingAid::unset_audio_busy()
 
 void HearingAid::set_data_langth()
 {
-    while (1) {
-        if (hci_can_send_command_packet_now()) {
-            hci_send_cmd(&hci_le_set_data_length, conn_handle, pdu_len, max_tx_time);
-            break;
-        }
-    }
+    hci_send_cmd(&hci_le_set_data_length, conn_handle, pdu_len, max_tx_time);
 }
 
 void HearingAid::send_acp_start()

--- a/src/hearing_aid.hpp
+++ b/src/hearing_aid.hpp
@@ -56,30 +56,20 @@ struct HearingAid
         DiscoverServices    = 1U <<  1,
         PairBond            = 1U <<  2,
         DataLength          = 1U <<  3,
-        DiscoverASHAChar    = 1U <<  4,
-        ReadROP             = 1U <<  5,
-        ReadPSM             = 1U <<  6,
-        DiscoverGAPChar     = 1U <<  7,
-        ReadDeviceName      = 1U <<  8,
-        DiscoverDISChar     = 1U <<  9,
-        ReadMfgName         = 1U << 10,
-        ReadModelNum        = 1U << 11,
-        ReadFWVers          = 1U << 12,
-        ReadSWVers          = 1U << 13,
-        DiscoverMFIChar     = 1U << 14,
-        ReadBattery         = 1U << 15,
-        ConnectL2CAP        = 1U << 16,
-        EnBattNotification  = 1U << 17,
-        EnASPNotification   = 1U << 18,
-        Finalize            = 1U << 19,
-        Audio               = 1U << 20,
+        DiscoverChars       = 1U <<  4,
+        ReadChars           = 1U <<  5,
+        ConnectL2CAP        = 1U <<  6,
+        EnBattNotification  = 1U <<  7,
+        EnASPNotification   = 1U <<  8,
+        Finalize            = 1U <<  9,
+        Audio               = 1U << 10,
         Disconnect          = 1U << 29,
         Done                = 1U << 30,
         ProcessBusy         = 1U << 31
     };
 
     enum AudioState : uint32_t {
-        AudioUnset               = 1U <<  0,
+        AudioUnset          = 1U <<  0,
         Ready               = 1U <<  1,
         Start               = 1U <<  2,
         Streaming           = 1U <<  3,
@@ -189,6 +179,33 @@ private:
         } mfi = {};
     } services = {};
 
+    std::array<gatt_client_service_t*, 4> service_arr = {
+        &services.gap.service,
+        &services.dis.service,
+        &services.asha.service,
+        &services.mfi.service
+    };
+    std::array<comm::EventType, 4> service_ev_arr = {
+        comm::EventType::DiscGAPChar, comm::EventType::DiscDISChar, comm::EventType::DiscASHAChar, comm::EventType::DiscMFIChar,
+    };
+    size_t service_index = 0;
+
+    std::array<gatt_client_characteristic_t*, 8> chars_arr = {
+        &services.gap.device_name,
+        &services.dis.manufacture_name,
+        &services.dis.model_num,
+        &services.dis.fw_vers,
+        &services.dis.sw_vers,
+        &services.asha.rop,
+        &services.asha.psm,
+        &services.mfi.battery,
+    };
+    std::array<comm::EventType, 8> chars_ev_arr = {
+        comm::EventType::DevNameRead, comm::EventType::MfgRead, comm::EventType::ModelRead, comm::EventType::FWRead,
+        comm::EventType::SWRead,      comm::EventType::ROPRead, comm::EventType::PSMRead,   comm::EventType::MfiBatteryRead,
+    };
+    size_t chars_index = 0;
+    constexpr static size_t cached_chars_index = 6;
     /* L2CAP credit management */
 
     uint16_t credits = 0;

--- a/src/hearing_aid.hpp
+++ b/src/hearing_aid.hpp
@@ -145,7 +145,7 @@ struct HearingAid
     static void handle_l2cap_cbm(PACKET_HANDLER_PARAMS);
     static void handle_notification_reg(PACKET_HANDLER_PARAMS);
     static void handle_gatt_notification(PACKET_HANDLER_PARAMS);
-    static void process_audio();
+    static bool process_audio();
 
 private:
     /* GATT structures */

--- a/website/docs/development.md
+++ b/website/docs/development.md
@@ -16,14 +16,6 @@ Create an environment variable called `PICO_SDK_PATH` that points to the downloa
 
     As of Pico SDK 2.2.0, the BT firmware has been updated to support DLE. 
 
-
-Pico-ASHA requires TinyUSB 0.20.0, which is newer than the TinyUSB included in the Pico SDK. There are two options to obtain this:
-
-1. Update the TinyUSB submodule in the SDK:
-    `cd pico-sdk/lib/tinyusb`
-    `git pull && git checkout 0.20.0`
-2. Download/clone TinyUSB to a separate directory and pass `-DPICO_TINYUSB_PATH=<path>` to cmake.
-
 Build pico-asha
 
 ```sh


### PR DESCRIPTION
I wasn't happy with how characteristics were discovered and read, I found it very cumbersome. So I hopefully simplified it a bit.

I decided to consolidate the separate timers for audio processing and other processing into a single timer handler. Other processing is delayed if audio is sent to hopefully prioritize audio sending over everything else.

I also fixed a bug which meant that Data Length Extensions were not set to the custom size.

Note: After this PR, I'm going to try and use an updated BTStack, so look forward to that PR soon (tm)