### PR TITLE
Add optional continuous streaming mode

### DIFF
--- a/gui/picoashacomm.cpp
+++ b/gui/picoashacomm.cpp
@@ -38,7 +38,10 @@ PicoAshaComm::PicoAshaComm(QObject *parent)
     QObject::connect(m_ui, &PicoAshaMainWindow::hciLogActionBtnClicked, this, &PicoAshaComm::onHciLogActionBtnClicked);
     QObject::connect(m_ui, &PicoAshaMainWindow::cmdRestartBtnClicked, this, &PicoAshaComm::onCmdRestartBtnClicked);
     QObject::connect(m_ui, &PicoAshaMainWindow::cmdConnAllowedBtnClicked, this, &PicoAshaComm::onCmdConnAllowedBtnClicked);
-    QObject::connect(m_ui, &PicoAshaMainWindow::cmdStreamingEnabledBtnClicked, this, &PicoAshaComm::onCmdStreamingEnabledBtnClicked);
+    QObject::connect(m_ui, &PicoAshaMainWindow::cmdStreamingEnabledBtnClicked,
+                     this, &PicoAshaComm::onCmdStreamingEnabledBtnClicked);
+    QObject::connect(m_ui, &PicoAshaMainWindow::streamingModeChanged,
+                     this, &PicoAshaComm::onStreamingModeChanged);
     QObject::connect(m_ui, &PicoAshaMainWindow::cmdRemoveBondBtnClicked, this, &PicoAshaComm::onCmdRemoveBondBtnClicked);
     QObject::connect(m_ui, &PicoAshaMainWindow::usbSettingsBtnClicked, this, &PicoAshaComm::onUsbSettingsBtnClicked);
     QObject::connect(m_ui, &PicoAshaMainWindow::pairWithAddress, this, &PicoAshaComm::onPairWithAddress);
@@ -239,6 +242,21 @@ void PicoAshaComm::onCmdStreamingEnabledBtnClicked(bool enabled)
     }
 }
 
+void PicoAshaComm::onStreamingModeChanged(asha::comm::StreamingMode mode)
+{
+    using namespace asha::comm;
+    bool res = sendCommandPacket(
+        {
+            .cmd = Command::StreamingMode,
+            .cmd_status = CmdStatus::CmdOk,
+            .data = {.streaming_mode = mode}
+        }
+        );
+    if (res) {
+        m_ui->setStreamingMode(mode);
+    }
+}
+
 void PicoAshaComm::onCmdRemoveBondBtnClicked()
 {
     using namespace asha::comm;
@@ -331,6 +349,9 @@ void PicoAshaComm::handleDecodedData(QByteArray const& decoded)
         m_ui->setPicoAshaVerStr(paFirmwareVers());
         m_ui->setConnectionsAllowed(intro.test_flag(IntroFlags::conn_allowed));
         m_ui->setAudioStreamingEnabled(intro.test_flag(IntroFlags::streaming_enabled));
+        m_ui->setStreamingMode(intro.test_flag(IntroFlags::continuous_streaming)
+                                 ? StreamingMode::Continuous
+                                 : StreamingMode::Eco);
         m_ui->setCmdBtnsEnabled(true);
         break;
     }

--- a/gui/picoashacomm.h
+++ b/gui/picoashacomm.h
@@ -90,6 +90,7 @@ public slots:
     void onCmdRestartBtnClicked();
     void onCmdConnAllowedBtnClicked(bool allowed);
     void onCmdStreamingEnabledBtnClicked(bool enabled);
+    void onStreamingModeChanged(asha::comm::StreamingMode mode);
     void onCmdRemoveBondBtnClicked();
     void onUsbSettingsBtnClicked(asha::comm::USBInfo const& usb_info);
     void onPairWithAddress(QByteArray const& addr, uint8_t addr_type);

--- a/gui/picoashamainwindow.cpp
+++ b/gui/picoashamainwindow.cpp
@@ -73,6 +73,26 @@ PicoAshaMainWindow::PicoAshaMainWindow(QWidget *parent)
     cmdGroup->setLayout(cmdLayout);
     mainVBox->addWidget(cmdGroup);
 
+    auto streamingModeGroup = new QGroupBox("Streaming mode");
+    auto streamingModeLayout = new QHBoxLayout;
+    streamingModeLayout->addStretch();
+
+    m_streamingEcoRadio = new QRadioButton("Eco");
+    m_streamingEcoRadio->setChecked(true);
+    streamingModeLayout->addWidget(m_streamingEcoRadio);
+
+    m_streamingContinuousRadio = new QRadioButton("Continuous");
+    streamingModeLayout->addWidget(m_streamingContinuousRadio);
+
+    auto continuousWarning = new QLabel(
+        "Continuous streaming increases hearing processor battery usage.");
+    continuousWarning->setWordWrap(true);
+    streamingModeLayout->addWidget(continuousWarning);
+    streamingModeLayout->addStretch();
+
+    streamingModeGroup->setLayout(streamingModeLayout);
+    mainVBox->addWidget(streamingModeGroup);
+
     auto usbGroup = new QGroupBox("USB Settings");
     auto usbLayout = new QHBoxLayout;
     usbLayout->addStretch();
@@ -116,6 +136,12 @@ PicoAshaMainWindow::PicoAshaMainWindow(QWidget *parent)
     });
     QObject::connect(m_cmdStreamingEnabledBtn, &QPushButton::clicked, this, [=, this](bool clicked) {
         emit cmdStreamingEnabledBtnClicked(!m_streamingEnabled);
+    });
+    QObject::connect(m_streamingEcoRadio, &QRadioButton::clicked, this, [this]() {
+        emit streamingModeChanged(asha::comm::StreamingMode::Eco);
+    });
+    QObject::connect(m_streamingContinuousRadio, &QRadioButton::clicked, this, [this]() {
+        emit streamingModeChanged(asha::comm::StreamingMode::Continuous);
     });
     QObject::connect(m_cmdRemoveBondBtn, &QPushButton::clicked, this, [=, this](bool clicked) {
         auto ans = QMessageBox::question(this, this->windowTitle(), "Are you sure you want to unpair connected hearing aids?");
@@ -318,6 +344,16 @@ void PicoAshaMainWindow::setAudioStreamingEnabled(bool enabled)
     }
 }
 
+void PicoAshaMainWindow::setStreamingMode(asha::comm::StreamingMode mode)
+{
+    if (!asha::comm::valid_streaming_mode(mode)) {
+        mode = asha::comm::StreamingMode::Eco;
+    }
+    m_streamingMode = mode;
+    m_streamingEcoRadio->setChecked(mode == asha::comm::StreamingMode::Eco);
+    m_streamingContinuousRadio->setChecked(mode == asha::comm::StreamingMode::Continuous);
+}
+
 void PicoAshaMainWindow::setUSBInfo(const asha::comm::USBInfo &usb_info)
 {
     m_usbInfo = usb_info;
@@ -410,6 +446,8 @@ void PicoAshaMainWindow::setCmdBtnsEnabled(bool enabled)
     m_cmdConnAllowedBtn->setEnabled(enabled);
     m_cmdStreamingEnabledBtn->setEnabled(enabled);
     m_cmdRemoveBondBtn->setEnabled(enabled);
+    m_streamingEcoRadio->setEnabled(enabled);
+    m_streamingContinuousRadio->setEnabled(enabled);
 }
 
 void PicoAshaMainWindow::setUSBWidgetsEnabled(bool enabled)

--- a/gui/picoashamainwindow.h
+++ b/gui/picoashamainwindow.h
@@ -5,6 +5,7 @@
 #include <QFrame>
 #include <QPlainTextEdit>
 #include <QPushButton>
+#include <QRadioButton>
 #include <QLabel>
 #include <QList>
 #include <QComboBox>
@@ -42,6 +43,7 @@ public:
     void setPicoAshaVerStr(QString const& version);
     void setConnectionsAllowed(bool allowed);
     void setAudioStreamingEnabled(bool enabled);
+    void setStreamingMode(asha::comm::StreamingMode mode);
     void setUSBInfo(asha::comm::USBInfo const& usb_info);
     void setUSBSettingsBtnState();
 
@@ -61,6 +63,7 @@ signals:
     void cmdRestartBtnClicked();
     void cmdConnAllowedBtnClicked(bool allowed);
     void cmdStreamingEnabledBtnClicked(bool enabled);
+    void streamingModeChanged(asha::comm::StreamingMode mode);
     void cmdRemoveBondBtnClicked();
     void usbSettingsBtnClicked(asha::comm::USBInfo const& usb_info);
     void pairWithAddress(QByteArray const& addr, uint8_t addr_type);
@@ -79,6 +82,9 @@ private:
     QPushButton* m_cmdStreamingEnabledBtn;
     QPushButton* m_cmdRemoveBondBtn;
 
+    QRadioButton* m_streamingEcoRadio;
+    QRadioButton* m_streamingContinuousRadio;
+
     QComboBox*   m_USBUacVersCombo;
     QSpinBox*    m_USBVolMinSpin;
     QSpinBox*    m_USBVolMaxSpin;
@@ -93,6 +99,7 @@ private:
     bool m_serialConnected;
     bool m_connectionsAllowed;
     bool m_streamingEnabled;
+    asha::comm::StreamingMode m_streamingMode = asha::comm::StreamingMode::Eco;
 
     asha::comm::USBInfo m_usbInfo;
     asha::comm::USBInfo fromUsbWidgets();

--- a/include/asha_comms.hpp
+++ b/include/asha_comms.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdarg>
 #include <cstdint>
 
 namespace asha
@@ -16,10 +17,18 @@ namespace comm
         constexpr uint16_t streaming_enabled = 1 << 1u;
         // UAC1: bit 0, UAC2: bit 1
         constexpr uint16_t uac_version = 1 << 2u;
+        // Eco: bit 0, Continuous: bit 1
+        constexpr uint16_t continuous_streaming = 1 << 3u;
     }
 
     enum class CSide : uint8_t {Left = 0, Right = 1, Unset = 2};
     enum class CMode : uint8_t {Mono = 0, Binaural = 1, Unset = 2};
+    enum class StreamingMode : uint8_t {Eco = 0, Continuous = 1};
+
+    constexpr bool valid_streaming_mode(StreamingMode mode)
+    {
+        return mode == StreamingMode::Eco || mode == StreamingMode::Continuous;
+    }
 
     enum class Type : uint8_t
     {
@@ -109,6 +118,7 @@ namespace comm
         IntroPacket,
         PairBond,
         USBSettings,
+        StreamingMode,
     };
 
     enum class CmdStatus : uint8_t
@@ -247,6 +257,7 @@ namespace comm
             bool      enable_hci;
             bool      allow_connect;
             bool      audio_streaming_enabled;
+            StreamingMode streaming_mode;
             struct {
                 uint8_t addr[6];
                 uint8_t addr_type;

--- a/src/asha_audio.c
+++ b/src/asha_audio.c
@@ -34,6 +34,9 @@ struct AshaAudioEncBuffer {
 static atomic_bool pcm_streaming;
 static atomic_bool encode_audio;
 static atomic_bool encode_mono;
+static atomic_bool continuous_streaming;
+static atomic_bool output_streaming_enabled;
+static atomic_bool streaming_session_reset;
 
 static atomic_uint_fast32_t write_index;
 
@@ -78,6 +81,9 @@ void asha_audio_init()
     pcm_streaming = false;
     encode_audio = false;
     encode_mono = false;
+    continuous_streaming = false;
+    output_streaming_enabled = true;
+    streaming_session_reset = false;
     write_index = 0u;
     vol_l = ASHA_USB_VOL_MIN;
     vol_r = ASHA_USB_VOL_MIN;
@@ -228,4 +234,38 @@ bool asha_audio_get_pcm_streaming_enabled()
 {
     bool pcm = pcm_streaming;
     return pcm;
+}
+
+void asha_audio_set_continuous_streaming_enabled(bool enabled)
+{
+    continuous_streaming = enabled;
+}
+
+bool asha_audio_get_continuous_streaming_enabled()
+{
+    bool enabled = continuous_streaming;
+    return enabled;
+}
+
+void asha_audio_set_output_streaming_enabled(bool enabled)
+{
+    output_streaming_enabled = enabled;
+}
+
+bool asha_audio_get_output_streaming_enabled()
+{
+    bool enabled = output_streaming_enabled;
+    return enabled;
+}
+
+void asha_audio_reset_streaming_session()
+{
+    pcm_streaming = false;
+    encode_audio = false;
+    streaming_session_reset = true;
+}
+
+bool asha_audio_take_streaming_session_reset()
+{
+    return atomic_exchange(&streaming_session_reset, false);
 }

--- a/src/asha_audio.h
+++ b/src/asha_audio.h
@@ -123,6 +123,36 @@ void asha_audio_set_pcm_streaming_enabled(bool enabled);
  */
 bool asha_audio_get_pcm_streaming_enabled();
 
+/**
+ * Selects whether USB audio gaps should be filled for continuous streaming.
+ */
+void asha_audio_set_continuous_streaming_enabled(bool enabled);
+
+/**
+ * Gets whether continuous streaming mode is selected.
+ */
+bool asha_audio_get_continuous_streaming_enabled();
+
+/**
+ * Shares the explicit audio-streaming enable state with the USB audio core.
+ */
+void asha_audio_set_output_streaming_enabled(bool enabled);
+
+/**
+ * Gets the explicit audio-streaming enable state.
+ */
+bool asha_audio_get_output_streaming_enabled();
+
+/**
+ * Stops encoding and asks the USB audio core to reset its streaming latch.
+ */
+void asha_audio_reset_streaming_session();
+
+/**
+ * Consumes a pending streaming-session reset request on the USB audio core.
+ */
+bool asha_audio_take_streaming_session_reset();
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/asha_bt.cpp
+++ b/src/asha_bt.cpp
@@ -194,6 +194,22 @@ static void process_serial_cmds()
                     }
                 }
                 break;
+            case Command::StreamingMode:
+                {
+                    auto mode = cmd_pkt.data.streaming_mode;
+                    if (!valid_streaming_mode(mode)) {
+                        cmd_pkt.cmd_status = CmdStatus::CmdError;
+                        break;
+                    }
+                    if (mode != runtime_settings.get_streaming_mode()
+                        && !runtime_settings.set_streaming_mode(mode)) {
+                        cmd_pkt.cmd_status = CmdStatus::CmdError;
+                        break;
+                    }
+                    asha_audio_set_continuous_streaming_enabled(
+                        mode == StreamingMode::Continuous);
+                }
+                break;
             default:
                 cmd_pkt.cmd_status = CmdStatus::CmdError;
                 break;

--- a/src/hearing_aid.cpp
+++ b/src/hearing_aid.cpp
@@ -235,6 +235,9 @@ void HearingAid::on_serial_host_connected()
     if (audio_streaming_enabled) {
         intro_flags |= IntroFlags::streaming_enabled;
     }
+    if (runtime_settings.get_streaming_mode() == StreamingMode::Continuous) {
+        intro_flags |= IntroFlags::continuous_streaming;
+    }
     send_intro_packet((int8_t)num_connected(), intro_flags);
     USBInfo usb_info = {
         .uac_vers = usb_settings.uac_version,
@@ -306,6 +309,10 @@ void HearingAid::set_connections_allowed(bool allowed)
 void HearingAid::set_audio_streaming_enabled(bool enabled)
 {
     audio_streaming_enabled = enabled;
+    asha_audio_set_output_streaming_enabled(enabled);
+    if (!enabled) {
+        asha_audio_reset_streaming_session();
+    }
 }
 
 void HearingAid::set_auto_pair_enabled(bool enabled)
@@ -416,6 +423,9 @@ void HearingAid::on_disconnected(hci_con_handle_t handle, uint8_t status, uint8_
     set_other_side_ptrs();
     ha->reset();
     int num_c = num_connected();
+    if (num_c == 0) {
+        asha_audio_reset_streaming_session();
+    }
     if (num_c == 1) {
         led_mgr.set_led_pattern(one_connected);
     } else {
@@ -1365,11 +1375,17 @@ void HearingAid::reset()
     other = nullptr;
     psm = 0;
     credits = 0;
+    zero_credits_cooldown = 0;
+    ready_stuck_ticks = 0;
     paired_and_bonded = false;
     process_delay_ticks = 0;
     error_count = 0;
     service_index = 0;
     chars_index = cached_chars_index;
+    curr_read_index = 0;
+    first_audio_send = false;
+    audio_data = nullptr;
+    stop_request_from_other = false;
     
     if (!cached) {
         memset(addr, 0U, sizeof(bd_addr_t));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,6 +50,8 @@ extern "C" int main()
         sleep_ms(50);
     }
 
+    asha_audio_set_continuous_streaming_enabled(
+        runtime_settings.get_streaming_mode() == comm::StreamingMode::Continuous);
     usb_settings = runtime_settings.get_usb_settings();
 
     // Init TinyUSB before stdio init

--- a/src/runtime_settings.cpp
+++ b/src/runtime_settings.cpp
@@ -50,6 +50,14 @@ USBSettings RuntimeSettings::get_usb_settings()
     return settings;
 }
 
+comm::StreamingMode RuntimeSettings::get_streaming_mode()
+{
+    mutex_enter_blocking(&mtx);
+    comm::StreamingMode mode = streaming_mode;
+    mutex_exit(&mtx);
+    return mode;
+}
+
 RuntimeSettings::operator bool()
 {
     mutex_enter_blocking(&mtx);
@@ -74,6 +82,10 @@ void RuntimeSettings::get_settings()
         if (!usb_settings) {
             usb_settings = USBSettings();
         }
+    }
+    if (!get_tlv_tag(Tag::StreamingMode, streaming_mode)
+        || !comm::valid_streaming_mode(streaming_mode)) {
+        streaming_mode = comm::StreamingMode::Eco;
     }
     got_settings = true;
 }
@@ -109,6 +121,20 @@ bool RuntimeSettings::set_usb_settings(USBSettings const &settings)
     if (settings && settings != usb_settings) {
         usb_settings = settings;
         res = store_tlv_tag(Tag::USBSetting, usb_settings);
+    }
+    mutex_exit(&mtx);
+    return res;
+}
+
+bool RuntimeSettings::set_streaming_mode(comm::StreamingMode mode)
+{
+    bool res = false;
+    mutex_enter_blocking(&mtx);
+    if (comm::valid_streaming_mode(mode) && mode != streaming_mode) {
+        res = store_tlv_tag(Tag::StreamingMode, mode);
+        if (res) {
+            streaming_mode = mode;
+        }
     }
     mutex_exit(&mtx);
     return res;

--- a/src/runtime_settings.hpp
+++ b/src/runtime_settings.hpp
@@ -7,6 +7,7 @@
 #include <btstack_tlv.h>
 
 #include "asha_audio.h"
+#include "asha_comms.hpp"
 #include "usb_common.hpp"
 
 namespace asha
@@ -26,10 +27,12 @@ struct RuntimeSettings
     bool get_hci_dump_enabled();
     bool get_full_set_paired();
     USBSettings get_usb_settings();
+    comm::StreamingMode get_streaming_mode();
 
     bool set_hci_dump_enabled(bool is_enabled);
     bool set_full_set_paired(bool have_full_set);
     bool set_usb_settings(USBSettings const& settings);
+    bool set_streaming_mode(comm::StreamingMode mode);
 
     // Store a pending setting in watchdog scratch registers so it can be
     // written to TLV after the watchdog reboot, avoiding a race between the
@@ -45,6 +48,7 @@ private:
         HCIDump = str_to_tag("PAHC"),
         FullSetPaired = str_to_tag("PAFS"),
         USBSetting = str_to_tag("PAUS"),
+        StreamingMode = str_to_tag("PASM"),
     };
 
     // used to store remote device in TLV
@@ -56,6 +60,7 @@ private:
     bool hci_dump_enabled = false;
     bool full_set_paired = false;
     USBSettings usb_settings = {};
+    comm::StreamingMode streaming_mode = comm::StreamingMode::Eco;
 
     mutex_t mtx = {};
 

--- a/src/usb_audio.cpp
+++ b/src/usb_audio.cpp
@@ -25,9 +25,11 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <stdio.h>
 #include <string.h>
 
+#include <pico/assert.h>
 #include <pico/time.h>
 
 #include <dsp/support_functions.h>
@@ -76,6 +78,19 @@ static uint32_t silence_counter = 0ul;
 // The silence_counter threshold by wish to signal streaming stopped
 static constexpr uint32_t silence_timeout = 10'000ul;
 
+// Continuous mode is paced from a 1 ms repeating timer. The callback only
+// publishes one pending tick; missed ticks are deliberately coalesced so the
+// encoder never catches up by generating frames faster than real time.
+static std::atomic_bool continuous_audio_tick = false;
+static repeating_timer_t continuous_audio_timer = {};
+static bool continuous_streaming_started = false;
+static bool continuous_frame_pending = false;
+static bool real_audio_playing = false;
+static bool previous_continuous_mode = false;
+static uint16_t continuous_sample_count = ASHA_PCM_PACKET_SIZE;
+static PCMStereoSample continuous_pcm[ASHA_PCM_MAX_SAMPLES] = {};
+static PCMStereoSample silent_pcm[ASHA_PCM_MAX_SAMPLES] = {};
+
 USBSettings usb_settings = {};
 
 USBSettings::operator bool() const
@@ -89,6 +104,22 @@ USBSettings::operator bool() const
 void audio_task(void);
 void serial_task(void);
 
+static bool continuous_audio_timer_cb([[maybe_unused]] repeating_timer_t* timer)
+{
+  continuous_audio_tick.store(true, std::memory_order_relaxed);
+  return true;
+}
+
+static void reset_usb_streaming_state()
+{
+  spk_data_size = 0;
+  continuous_streaming_started = false;
+  continuous_frame_pending = false;
+  real_audio_playing = false;
+  continuous_audio_tick.store(false, std::memory_order_relaxed);
+  asha_audio_reset_streaming_session();
+}
+
 void tud_cdc_line_state_cb([[maybe_unused]] uint8_t itf, 
                            [[maybe_unused]] bool dtr, 
                            [[maybe_unused]] bool rts)
@@ -100,6 +131,8 @@ void usb_main(void)
   TU_LOG1("Headset running\n");
   // int err = 0;
   // srs = speex_resampler_init(2, 48000, 16000, 0, &err);
+  hard_assert(add_repeating_timer_us(-1000, continuous_audio_timer_cb, nullptr,
+                                     &continuous_audio_timer));
   while (1)
   {
     tud_task(); // TinyUSB device task
@@ -114,11 +147,13 @@ void usb_main(void)
 // Invoked when device is mounted
 void tud_mount_cb(void)
 {
+  reset_usb_streaming_state();
 }
 
 // Invoked when device is unmounted
 void tud_umount_cb(void)
 {
+  reset_usb_streaming_state();
 }
 
 // Invoked when usb bus is suspended
@@ -127,6 +162,7 @@ void tud_umount_cb(void)
 void tud_suspend_cb(bool remote_wakeup_en)
 {
   (void)remote_wakeup_en;
+  reset_usb_streaming_state();
 }
 
 // Invoked when usb bus is resumed
@@ -543,6 +579,38 @@ extern "C" bool tud_audio_rx_done_isr(uint8_t rhport, uint16_t n_bytes_received,
 void audio_task(void)
 {
   absolute_time_t now = get_absolute_time();
+
+  if (asha_audio_take_streaming_session_reset()) {
+    continuous_streaming_started = false;
+    continuous_frame_pending = false;
+    real_audio_playing = false;
+    continuous_audio_tick.store(false, std::memory_order_relaxed);
+  }
+
+  if (real_audio_playing && absolute_time_diff_us(last_packet_time, now) > 5000) {
+    real_audio_playing = false;
+  }
+
+  bool continuous_mode = asha_audio_get_continuous_streaming_enabled();
+  bool output_streaming_enabled = asha_audio_get_output_streaming_enabled();
+  if (previous_continuous_mode && !continuous_mode) {
+    continuous_streaming_started = false;
+    continuous_frame_pending = false;
+    if (!real_audio_playing) {
+      // A mode change to Eco while paused should take the normal ASHA stop
+      // path immediately and remain stopped until non-zero USB audio returns.
+      silence_counter = silence_timeout;
+      asha_audio_set_pcm_streaming_enabled(false);
+    }
+  }
+  previous_continuous_mode = continuous_mode;
+
+  if (continuous_mode && !output_streaming_enabled) {
+    continuous_streaming_started = false;
+    continuous_frame_pending = false;
+    asha_audio_set_pcm_streaming_enabled(false);
+  }
+
   if (spk_data_size) {
     uint16_t s = spk_data_size;
     spk_data_size = 0;
@@ -550,24 +618,57 @@ void audio_task(void)
     
     if (s == spk_data_size_16 || s == spk_data_size_48) {
       tud_audio_read(spk_buf, s);
+      uint16_t sample_count = s == spk_data_size_16 ? 16u : 48u;
       
       asha_audio_set_curr_usb_vol(mute[0] ? ASHA_USB_VOL_MUTE : volume[0], 
                                   mute[1] ? ASHA_USB_VOL_MUTE : volume[1], 
                                   mute[2] ? ASHA_USB_VOL_MUTE : volume[2]);
 
-      if (std::all_of(std::begin(spk_buf), std::end(spk_buf), [](PCMStereoSample s) {return s.left == 0 && s.right == 0; })) {
-        ++silence_counter;
+      if (continuous_mode) {
+        real_audio_playing = !std::all_of(spk_buf, spk_buf + sample_count,
+          [](PCMStereoSample sample) { return sample.left == 0 && sample.right == 0; });
+        if (real_audio_playing && output_streaming_enabled) {
+          continuous_streaming_started = true;
+        }
+        asha_audio_set_pcm_streaming_enabled(
+          output_streaming_enabled && continuous_streaming_started);
+
+        if (continuous_streaming_started && output_streaming_enabled) {
+          memcpy(continuous_pcm, spk_buf, s);
+          continuous_sample_count = sample_count;
+          continuous_frame_pending = true;
+        }
       } else {
-        silence_counter = 0;
+        if (std::all_of(std::begin(spk_buf), std::end(spk_buf), [](PCMStereoSample s) {return s.left == 0 && s.right == 0; })) {
+          ++silence_counter;
+        } else {
+          silence_counter = 0;
+        }
+        asha_audio_set_pcm_streaming_enabled((silence_counter >= silence_timeout) ? false : true);
+        asha_audio_encode_1ms_pcm(spk_buf, sample_count);
       }
-      asha_audio_set_pcm_streaming_enabled((silence_counter >= silence_timeout) ? false : true);
-      asha_audio_encode_1ms_pcm(spk_buf, s == spk_data_size_16 ? 16u : 48u);
     }
   } else {
-    if (absolute_time_diff_us(last_packet_time, now) > 5000) {
+    if (!continuous_mode && absolute_time_diff_us(last_packet_time, now) > 5000) {
       asha_audio_set_pcm_streaming_enabled(false);
       last_packet_time = now;
     }
+  }
+
+  if (continuous_mode && output_streaming_enabled && continuous_streaming_started
+      && continuous_audio_tick.exchange(false, std::memory_order_relaxed)) {
+    if (continuous_frame_pending) {
+      asha_audio_encode_1ms_pcm(continuous_pcm, continuous_sample_count);
+      continuous_frame_pending = false;
+    } else {
+      uint16_t sample_count = current_sample_rate == 48000
+                                ? ASHA_PCM_MAX_SAMPLES
+                                : ASHA_PCM_PACKET_SIZE;
+      asha_audio_encode_1ms_pcm(silent_pcm, sample_count);
+    }
+  } else if (!continuous_mode || !output_streaming_enabled
+             || !continuous_streaming_started) {
+    continuous_audio_tick.store(false, std::memory_order_relaxed);
   }
 }
 


### PR DESCRIPTION
## Summary

Adds an optional Continuous streaming mode while preserving the existing
power-saving behavior as Eco mode.

## Motivation

With Cochlear Nucleus 7, stopping or pausing media causes the processor to
exit streaming mode. Resuming media causes it to enter streaming mode again,
including the transition sound. Example: YouTube you stopped video for 2 seconds for think, then resume video and you're not hearing first word for author's video, you will hear switching mode to bluetooth. Or discord all will to fall silent, then someone will start speaking, and again you won't hear first his word. 

Continuous mode keeps the ASHA stream active with correctly timed silent
audio frames after real audio has started.

## Changes

- Added two streaming modes:
  - Eco (default)
  - Continuous
- Added a GUI control for selecting the mode.
- Added a warning that Continuous mode increases hearing processor battery usage.
- Passed the setting through the existing GUI/firmware control protocol.
- Preserved Eco as the default for existing users.
- Continuous mode waits for actual audio before activating.
- Silent frames are generated at the normal real-time rate while media is paused.
- Real audio resumes without restarting the ASHA stream.

## Hardware testing

Tested with:

- Raspberry Pi Pico 2 W
- Cochlear Nucleus 7
- Windows
- UAC2

Confirmed:

- Eco mode retains the original behavior.
- Continuous mode keeps the Nucleus 7 in streaming mode during pauses.
- Playback resumes without another streaming transition.
- Switching back to Eco stops the stream normally.
- HCI logging still works on current `main`.

## Notes

Continuous mode may increase hearing processor battery consumption.

This PR does not modify HCI logging or implement microphone/stream mixing.
Programmed by Codex 5.6 Sol very-high, better than senior